### PR TITLE
[codex] Add clipboard service

### DIFF
--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -48,6 +48,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arboard"
+version = "3.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0348a1c054491f4bfe6ab86a7b6ab1e44e45d899005de92f58b3df180b36ddaf"
+dependencies = [
+ "clipboard-win",
+ "image",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-foundation",
+ "parking_lot",
+ "percent-encoding",
+ "windows-sys 0.60.2",
+ "wl-clipboard-rs",
+ "x11rb",
+]
+
+[[package]]
 name = "async-broadcast"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -463,6 +484,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clipboard-win"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
+dependencies = [
+ "error-code",
+]
+
+[[package]]
 name = "cliplingo-desktop"
 version = "0.1.0"
 dependencies = [
@@ -470,6 +500,7 @@ dependencies = [
  "serde_json",
  "tauri",
  "tauri-build",
+ "tauri-plugin-clipboard-manager",
  "tauri-plugin-opener",
 ]
 
@@ -580,6 +611,12 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -812,6 +849,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "downcast-rs"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
+
+[[package]]
 name = "dpi"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -922,6 +965,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "error-code"
+version = "3.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
+
+[[package]]
 name = "event-listener"
 version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -949,6 +998,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
+name = "fax"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05de7d48f37cd6730705cbca900770cab77a89f413d23e100ad7fad7795a0ab"
+dependencies = [
+ "fax_derive",
+]
+
+[[package]]
+name = "fax_derive"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0aca10fb742cb43f9e7bb8467c91aa9bcb8e3ffbc6a6f7389bb93ffc920577d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "fdeflate"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -972,6 +1041,12 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "flate2"
@@ -1250,6 +1325,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "gethostname"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
+dependencies = [
+ "rustix",
+ "windows-link 0.2.1",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1442,6 +1527,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
 ]
 
 [[package]]
@@ -1753,6 +1849,7 @@ dependencies = [
  "moxcms",
  "num-traits",
  "png 0.18.1",
+ "tiff",
 ]
 
 [[package]]
@@ -2198,6 +2295,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
 
 [[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2254,6 +2360,7 @@ dependencies = [
  "block2",
  "objc2",
  "objc2-core-foundation",
+ "objc2-core-graphics",
  "objc2-foundation",
 ]
 
@@ -2392,6 +2499,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "os_pipe"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "pango"
 version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2456,6 +2573,17 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "petgraph"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
+dependencies = [
+ "fixedbitset",
+ "hashbrown 0.15.5",
+ "indexmap 2.13.1",
+]
 
 [[package]]
 name = "phf"
@@ -2675,7 +2803,7 @@ checksum = "740ebea15c5d1428f910cd1a5f52cebf8d25006245ed8ade92702f4943d91e07"
 dependencies = [
  "base64 0.22.1",
  "indexmap 2.13.1",
- "quick-xml",
+ "quick-xml 0.38.4",
  "serde",
  "time",
 ]
@@ -2835,10 +2963,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5a041e753da8b807c9255f28de81879c78c876392ff2469cde94799b2896b9d"
 
 [[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
+
+[[package]]
 name = "quick-xml"
 version = "0.38.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.39.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "958f21e8e7ceb5a1aa7fa87fab28e7c75976e0bfe7e23ff069e0a260f894067d"
 dependencies = [
  "memchr",
 ]
@@ -3798,6 +3941,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-clipboard-manager"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "206dc20af4ed210748ba945c2774e60fd0acd52b9a73a028402caf809e9b6ecf"
+dependencies = [
+ "arboard",
+ "log",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "tauri-plugin-opener"
 version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3991,6 +4149,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "tiff"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b63feaf3343d35b6ca4d50483f94843803b0f51634937cc2ec519fc32232bc52"
+dependencies = [
+ "fax",
+ "flate2",
+ "half",
+ "quick-error",
+ "weezl",
+ "zune-jpeg",
 ]
 
 [[package]]
@@ -4262,6 +4434,17 @@ dependencies = [
  "serde",
  "thiserror 2.0.18",
  "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "tree_magic_mini"
+version = "3.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8765b90061cba6c22b5831f675da109ae5561588290f9fa2317adab2714d5a6"
+dependencies = [
+ "memchr",
+ "nom",
+ "petgraph",
 ]
 
 [[package]]
@@ -4585,6 +4768,76 @@ dependencies = [
 ]
 
 [[package]]
+name = "wayland-backend"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2857dd20b54e916ec7253b3d6b4d5c4d7d4ca2c33c2e11c6c76a99bd8744755d"
+dependencies = [
+ "cc",
+ "downcast-rs",
+ "rustix",
+ "smallvec",
+ "wayland-sys",
+]
+
+[[package]]
+name = "wayland-client"
+version = "0.31.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "645c7c96bb74690c3189b5c9cb4ca1627062bb23693a4fad9d8c3de958260144"
+dependencies = [
+ "bitflags 2.11.0",
+ "rustix",
+ "wayland-backend",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols"
+version = "0.32.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "563a85523cade2429938e790815fd7319062103b9f4a2dc806e9b53b95982d8f"
+dependencies = [
+ "bitflags 2.11.0",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols-wlr"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb04e52f7836d7c7976c78ca0250d61e33873c34156a2a1fc9474828ec268234"
+dependencies = [
+ "bitflags 2.11.0",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-scanner"
+version = "0.31.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c324a910fd86ebdc364a3e61ec1f11737d3b1d6c273c0239ee8ff4bc0d24b4a"
+dependencies = [
+ "proc-macro2",
+ "quick-xml 0.39.2",
+ "quote",
+]
+
+[[package]]
+name = "wayland-sys"
+version = "0.31.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8eab23fefc9e41f8e841df4a9c707e8a8c4ed26e944ef69297184de2785e3be"
+dependencies = [
+ "pkg-config",
+]
+
+[[package]]
 name = "web-sys"
 version = "0.3.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4685,6 +4938,12 @@ dependencies = [
  "windows",
  "windows-core 0.61.2",
 ]
+
+[[package]]
+name = "weezl"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
 name = "winapi"
@@ -5237,6 +5496,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "wl-clipboard-rs"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9651471a32e87d96ef3a127715382b2d11cc7c8bb9822ded8a7cc94072eb0a3"
+dependencies = [
+ "libc",
+ "log",
+ "os_pipe",
+ "rustix",
+ "thiserror 2.0.18",
+ "tree_magic_mini",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-protocols-wlr",
+]
+
+[[package]]
 name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5306,6 +5583,23 @@ dependencies = [
  "once_cell",
  "pkg-config",
 ]
+
+[[package]]
+name = "x11rb"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9993aa5be5a26815fe2c3eacfc1fde061fc1a1f094bf1ad2a18bf9c495dd7414"
+dependencies = [
+ "gethostname",
+ "rustix",
+ "x11rb-protocol",
+]
+
+[[package]]
+name = "x11rb-protocol"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
 
 [[package]]
 name = "yoke"
@@ -5470,6 +5764,21 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zune-core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
+
+[[package]]
+name = "zune-jpeg"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
+dependencies = [
+ "zune-core",
+]
 
 [[package]]
 name = "zvariant"

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -20,5 +20,6 @@ tauri-build = { version = "2", features = [] }
 [dependencies]
 tauri = { version = "2", features = ["tray-icon", "image-png"] }
 tauri-plugin-opener = "2"
+tauri-plugin-clipboard-manager = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/apps/desktop/src-tauri/capabilities/default.json
+++ b/apps/desktop/src-tauri/capabilities/default.json
@@ -3,5 +3,10 @@
   "identifier": "default",
   "description": "Capability for the main window",
   "windows": ["main"],
-  "permissions": ["core:default", "core:window:default", "opener:default"]
+  "permissions": [
+    "core:default",
+    "core:window:default",
+    "opener:default",
+    "clipboard-manager:allow-read-text"
+  ]
 }

--- a/apps/desktop/src-tauri/capabilities/settings.json
+++ b/apps/desktop/src-tauri/capabilities/settings.json
@@ -3,5 +3,10 @@
   "identifier": "settings-window",
   "description": "Capability for the settings window",
   "windows": ["settings"],
-  "permissions": ["core:default", "core:window:default", "opener:default"]
+  "permissions": [
+    "core:default",
+    "core:window:default",
+    "opener:default",
+    "clipboard-manager:allow-read-text"
+  ]
 }

--- a/apps/desktop/src-tauri/capabilities/translation-popup.json
+++ b/apps/desktop/src-tauri/capabilities/translation-popup.json
@@ -3,5 +3,10 @@
   "identifier": "translation-popup-window",
   "description": "Capability for the translation popup window",
   "windows": ["translation-popup"],
-  "permissions": ["core:default", "core:window:default", "opener:default"]
+  "permissions": [
+    "core:default",
+    "core:window:default",
+    "opener:default",
+    "clipboard-manager:allow-read-text"
+  ]
 }

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -1,3 +1,6 @@
+mod services;
+
+use services::clipboard::{read_clipboard_text, read_clipboard_text_with_limits, ClipboardLimits};
 use tauri::{
     image::Image,
     menu::{Menu, MenuItem, PredefinedMenuItem},
@@ -92,9 +95,7 @@ fn present_main_window(app: &AppHandle) -> tauri::Result<()> {
 }
 
 fn present_settings_window(app: &AppHandle) -> tauri::Result<()> {
-    let window = ensure_window(app, SETTINGS_WINDOW_LABEL, || {
-        create_settings_window(app)
-    })?;
+    let window = ensure_window(app, SETTINGS_WINDOW_LABEL, || create_settings_window(app))?;
     reveal_window(&window)
 }
 
@@ -133,7 +134,9 @@ async fn hide_window(app: AppHandle, label: String) -> tauri::Result<()> {
 
 #[tauri::command]
 async fn toggle_main_window(app: AppHandle) -> tauri::Result<()> {
-    let window = ensure_window(&app, MAIN_WINDOW_LABEL, || Err(tauri::Error::WindowNotFound))?;
+    let window = ensure_window(&app, MAIN_WINDOW_LABEL, || {
+        Err(tauri::Error::WindowNotFound)
+    })?;
 
     if window.is_visible()? {
         window.hide()?;
@@ -144,8 +147,28 @@ async fn toggle_main_window(app: AppHandle) -> tauri::Result<()> {
     Ok(())
 }
 
+#[tauri::command]
+async fn read_system_clipboard(
+    app: AppHandle,
+    max_chars: Option<usize>,
+) -> Result<services::clipboard::ClipboardText, String> {
+    match max_chars {
+        Some(max_chars) => {
+            let limits = ClipboardLimits::new(max_chars).map_err(|error| error.to_string())?;
+            read_clipboard_text_with_limits(app, limits).map_err(|error| error.to_string())
+        }
+        None => read_clipboard_text(app).map_err(|error| error.to_string()),
+    }
+}
+
 fn build_tray(app: &AppHandle) -> tauri::Result<()> {
-    let show_main = MenuItem::with_id(app, TRAY_SHOW_MAIN_ID, "Show Main Window", true, None::<&str>)?;
+    let show_main = MenuItem::with_id(
+        app,
+        TRAY_SHOW_MAIN_ID,
+        "Show Main Window",
+        true,
+        None::<&str>,
+    )?;
     let show_settings =
         MenuItem::with_id(app, TRAY_SHOW_SETTINGS_ID, "Settings", true, None::<&str>)?;
     let separator = PredefinedMenuItem::separator(app)?;
@@ -179,6 +202,7 @@ fn build_tray(app: &AppHandle) -> tauri::Result<()> {
 pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
+        .plugin(tauri_plugin_clipboard_manager::init())
         .setup(|app| {
             let handle = app.handle().clone();
             let main_window = if let Some(window) = handle.get_webview_window(MAIN_WINDOW_LABEL) {
@@ -196,7 +220,8 @@ pub fn run() {
             show_settings_window,
             show_translation_popup,
             hide_window,
-            toggle_main_window
+            toggle_main_window,
+            read_system_clipboard
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/apps/desktop/src-tauri/src/services/clipboard.rs
+++ b/apps/desktop/src-tauri/src/services/clipboard.rs
@@ -1,0 +1,309 @@
+use serde::{Deserialize, Serialize};
+use tauri::AppHandle;
+use tauri_plugin_clipboard_manager::ClipboardExt;
+
+pub const DEFAULT_MAX_CHARS: usize = 8_000;
+pub const HARD_MAX_CHARS: usize = 50_000;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ClipboardLimits {
+    pub max_chars: usize,
+}
+
+impl Default for ClipboardLimits {
+    fn default() -> Self {
+        Self {
+            max_chars: DEFAULT_MAX_CHARS,
+        }
+    }
+}
+
+impl ClipboardLimits {
+    pub fn new(max_chars: usize) -> Result<Self, ClipboardServiceError> {
+        if max_chars == 0 {
+            return Err(ClipboardServiceError::InvalidLimit {
+                max_chars,
+                hard_max_chars: HARD_MAX_CHARS,
+            });
+        }
+
+        if max_chars > HARD_MAX_CHARS {
+            return Err(ClipboardServiceError::InvalidLimit {
+                max_chars,
+                hard_max_chars: HARD_MAX_CHARS,
+            });
+        }
+
+        Ok(Self { max_chars })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ClipboardText {
+    pub text: String,
+    pub character_count: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ClipboardServiceError {
+    EmptyText,
+    UnsupportedContent,
+    TooLong {
+        character_count: usize,
+        max_chars: usize,
+    },
+    InvalidLimit {
+        max_chars: usize,
+        hard_max_chars: usize,
+    },
+    ReadFailed(String),
+}
+
+impl std::fmt::Display for ClipboardServiceError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::EmptyText => f.write_str("clipboard text is empty"),
+            Self::UnsupportedContent => f.write_str("clipboard content is not plain text"),
+            Self::TooLong {
+                character_count,
+                max_chars,
+            } => write!(
+                f,
+                "clipboard text exceeds the configured limit: {character_count} > {max_chars}"
+            ),
+            Self::InvalidLimit {
+                max_chars,
+                hard_max_chars,
+            } => write!(
+                f,
+                "invalid clipboard limit {max_chars}; hard maximum is {hard_max_chars}"
+            ),
+            Self::ReadFailed(message) => write!(f, "failed to read clipboard text: {message}"),
+        }
+    }
+}
+
+impl std::error::Error for ClipboardServiceError {}
+
+pub trait ClipboardReader {
+    fn read_text(&self) -> Result<Option<String>, ClipboardServiceError>;
+}
+
+pub struct ClipboardService<R> {
+    reader: R,
+    limits: ClipboardLimits,
+}
+
+impl<R> ClipboardService<R>
+where
+    R: ClipboardReader,
+{
+    pub fn new(reader: R, limits: ClipboardLimits) -> Self {
+        Self { reader, limits }
+    }
+
+    pub fn read_normalized_text(&self) -> Result<ClipboardText, ClipboardServiceError> {
+        let Some(raw_text) = self.reader.read_text()? else {
+            return Err(ClipboardServiceError::UnsupportedContent);
+        };
+
+        let text = normalize_clipboard_text(&raw_text);
+        if text.is_empty() {
+            return Err(ClipboardServiceError::EmptyText);
+        }
+
+        let character_count = text.chars().count();
+        if character_count > self.limits.max_chars {
+            return Err(ClipboardServiceError::TooLong {
+                character_count,
+                max_chars: self.limits.max_chars,
+            });
+        }
+
+        Ok(ClipboardText {
+            text,
+            character_count,
+        })
+    }
+}
+
+pub struct TauriClipboardReader {
+    app: AppHandle,
+}
+
+impl TauriClipboardReader {
+    pub fn new(app: AppHandle) -> Self {
+        Self { app }
+    }
+}
+
+impl ClipboardReader for TauriClipboardReader {
+    fn read_text(&self) -> Result<Option<String>, ClipboardServiceError> {
+        let text = self
+            .app
+            .clipboard()
+            .read_text()
+            .map_err(|error| ClipboardServiceError::ReadFailed(error.to_string()))?;
+
+        if text.is_empty() {
+            return Ok(None);
+        }
+
+        Ok(Some(text))
+    }
+}
+
+pub fn read_clipboard_text(app: AppHandle) -> Result<ClipboardText, ClipboardServiceError> {
+    read_clipboard_text_with_limits(app, ClipboardLimits::default())
+}
+
+pub fn read_clipboard_text_with_limits(
+    app: AppHandle,
+    limits: ClipboardLimits,
+) -> Result<ClipboardText, ClipboardServiceError> {
+    let reader = TauriClipboardReader::new(app);
+    let service = ClipboardService::new(reader, limits);
+    service.read_normalized_text()
+}
+
+pub fn normalize_clipboard_text(input: &str) -> String {
+    let normalized_newlines = input.replace("\r\n", "\n").replace('\r', "\n");
+    let filtered: String = normalized_newlines
+        .chars()
+        .filter(|character| is_allowed_clipboard_character(*character))
+        .collect();
+
+    let mut compacted = String::with_capacity(filtered.len());
+    for character in filtered.chars() {
+        if character == '\n' {
+            while matches!(compacted.chars().last(), Some(' ' | '\t')) {
+                compacted.pop();
+            }
+        }
+
+        compacted.push(character);
+    }
+
+    compacted.trim().to_owned()
+}
+
+fn is_allowed_clipboard_character(character: char) -> bool {
+    matches!(character, '\n' | '\t')
+        || (!character.is_control()
+            && character != '\u{feff}'
+            && character != '\u{200b}'
+            && character != '\u{200c}'
+            && character != '\u{200d}'
+            && character != '\u{2060}')
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct FakeClipboardReader {
+        result: Result<Option<String>, ClipboardServiceError>,
+    }
+
+    impl ClipboardReader for FakeClipboardReader {
+        fn read_text(&self) -> Result<Option<String>, ClipboardServiceError> {
+            self.result.clone()
+        }
+    }
+
+    #[test]
+    fn normalize_clipboard_text_strips_control_characters_and_standardizes_newlines() {
+        let input = "\u{feff}  hello\r\nworld\u{200b}\rtest\tvalue\u{0000}  ";
+
+        let output = normalize_clipboard_text(input);
+
+        assert_eq!(output, "hello\nworld\ntest\tvalue");
+    }
+
+    #[test]
+    fn normalize_clipboard_text_preserves_paragraph_structure() {
+        let input = " first line \r\n\r\nsecond line \r third line ";
+
+        let output = normalize_clipboard_text(input);
+
+        assert_eq!(output, "first line\n\nsecond line\n third line");
+    }
+
+    #[test]
+    fn read_normalized_text_rejects_empty_text() {
+        let reader = FakeClipboardReader {
+            result: Ok(Some("   \r\n\t".to_string())),
+        };
+        let service = ClipboardService::new(reader, ClipboardLimits::default());
+
+        let error = service.read_normalized_text().unwrap_err();
+
+        assert_eq!(error, ClipboardServiceError::EmptyText);
+    }
+
+    #[test]
+    fn read_normalized_text_rejects_non_text_clipboard_content() {
+        let reader = FakeClipboardReader { result: Ok(None) };
+        let service = ClipboardService::new(reader, ClipboardLimits::default());
+
+        let error = service.read_normalized_text().unwrap_err();
+
+        assert_eq!(error, ClipboardServiceError::UnsupportedContent);
+    }
+
+    #[test]
+    fn read_normalized_text_rejects_over_limit_payloads() {
+        let reader = FakeClipboardReader {
+            result: Ok(Some("a".repeat(9_000))),
+        };
+        let service =
+            ClipboardService::new(reader, ClipboardLimits::new(8_000).expect("valid limit"));
+
+        let error = service.read_normalized_text().unwrap_err();
+
+        assert_eq!(
+            error,
+            ClipboardServiceError::TooLong {
+                character_count: 9_000,
+                max_chars: 8_000,
+            }
+        );
+    }
+
+    #[test]
+    fn read_normalized_text_returns_normalized_clipboard_text() {
+        let reader = FakeClipboardReader {
+            result: Ok(Some("  hello\r\nworld  ".to_string())),
+        };
+        let service = ClipboardService::new(reader, ClipboardLimits::default());
+
+        let output = service.read_normalized_text().expect("normalized text");
+
+        assert_eq!(
+            output,
+            ClipboardText {
+                text: "hello\nworld".to_string(),
+                character_count: 11,
+            }
+        );
+    }
+
+    #[test]
+    fn clipboard_limits_rejects_zero_and_hard_max_overflow() {
+        assert_eq!(
+            ClipboardLimits::new(0).unwrap_err(),
+            ClipboardServiceError::InvalidLimit {
+                max_chars: 0,
+                hard_max_chars: HARD_MAX_CHARS,
+            }
+        );
+
+        assert_eq!(
+            ClipboardLimits::new(HARD_MAX_CHARS + 1).unwrap_err(),
+            ClipboardServiceError::InvalidLimit {
+                max_chars: HARD_MAX_CHARS + 1,
+                hard_max_chars: HARD_MAX_CHARS,
+            }
+        );
+    }
+}

--- a/apps/desktop/src-tauri/src/services/mod.rs
+++ b/apps/desktop/src-tauri/src/services/mod.rs
@@ -1,0 +1,1 @@
+pub mod clipboard;


### PR DESCRIPTION
## Summary
- add a Rust clipboard service that reads plain-text clipboard content through Tauri
- normalize clipboard text by trimming, converting newlines, stripping control characters, and enforcing length limits
- add tests for empty input, non-text input, over-limit payloads, and normalization behavior
- enable clipboard read permissions for the desktop windows

## Validation
- `cargo fmt --manifest-path src-tauri/Cargo.toml`
- `cargo test --manifest-path src-tauri/Cargo.toml`
- `pnpm lint`

Refs #5
