### PR TITLE
[codex] Add config persistence and secure storage

### DIFF
--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -496,12 +496,15 @@ dependencies = [
 name = "cliplingo-desktop"
 version = "0.1.0"
 dependencies = [
+ "directories",
+ "keyring",
  "serde",
  "serde_json",
  "tauri",
  "tauri-build",
  "tauri-plugin-clipboard-manager",
  "tauri-plugin-opener",
+ "toml 0.8.2",
 ]
 
 [[package]]
@@ -541,6 +544,16 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
@@ -562,7 +575,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "064badf302c3194842cf2c5d61f56cc88e54a759313879cdf03abdd27d0c3b97"
 dependencies = [
  "bitflags 2.11.0",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-graphics-types",
  "foreign-types",
  "libc",
@@ -575,7 +588,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb"
 dependencies = [
  "bitflags 2.11.0",
- "core-foundation",
+ "core-foundation 0.10.1",
  "libc",
 ]
 
@@ -713,6 +726,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "dbus"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21b3aa68d7e7abee336255bd7248ea965cc393f3e70411135a6f6a4b651345d4"
+dependencies = [
+ "libc",
+ "libdbus-sys",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "dbus-secret-service"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "708b509edf7889e53d7efb0ffadd994cc6c2345ccb62f55cfd6b0682165e4fa6"
+dependencies = [
+ "dbus",
+ "zeroize",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -764,6 +798,15 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+]
+
+[[package]]
+name = "directories"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16f5094c54661b38d03bd7e50df373292118db60b585c08a411c6d840017fe7d"
+dependencies = [
+ "dirs-sys",
 ]
 
 [[package]]
@@ -2038,6 +2081,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "keyring"
+version = "3.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eebcc3aff044e5944a8fbaf69eb277d11986064cba30c468730e8b9909fb551c"
+dependencies = [
+ "byteorder",
+ "dbus-secret-service",
+ "log",
+ "security-framework 2.11.1",
+ "security-framework 3.7.0",
+ "windows-sys 0.60.2",
+ "zeroize",
+]
+
+[[package]]
 name = "kuchikiki"
 version = "0.8.8-speedreader"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2084,6 +2142,15 @@ name = "libc"
 version = "0.2.184"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
+
+[[package]]
+name = "libdbus-sys"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "328c4789d42200f1eeec05bd86c9c13c7f091d2ba9a6ea35acdf51f31bc0f043"
+dependencies = [
+ "pkg-config",
+]
 
 [[package]]
 name = "libloading"
@@ -3298,6 +3365,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags 2.11.0",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags 2.11.0",
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "selectors"
 version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3761,7 +3864,7 @@ checksum = "9103edf55f2da3c82aea4c7fab7c4241032bfeea0e71fa557d98e00e7ce7cc20"
 dependencies = [
  "bitflags 2.11.0",
  "block2",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-graphics",
  "crossbeam-channel",
  "dispatch2",
@@ -5724,6 +5827,26 @@ dependencies = [
  "quote",
  "syn 2.0.117",
  "synstructure",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -21,5 +21,8 @@ tauri-build = { version = "2", features = [] }
 tauri = { version = "2", features = ["tray-icon", "image-png"] }
 tauri-plugin-opener = "2"
 tauri-plugin-clipboard-manager = "2"
+directories = "6"
+keyring = { version = "3", features = ["apple-native", "windows-native", "sync-secret-service"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+toml = "0.8"

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -1,6 +1,13 @@
+mod models;
 mod services;
+mod storage;
 
-use services::clipboard::{read_clipboard_text, read_clipboard_text_with_limits, ClipboardLimits};
+use models::config::{AppConfigRecord, ProviderConfigRecord};
+use services::{
+    clipboard::{read_clipboard_text, read_clipboard_text_with_limits, ClipboardLimits},
+    config::{ConfigService, ProviderSecretStatus},
+};
+use storage::{fs_paths::ProjectPathProvider, secure_storage::KeyringSecretStore};
 use tauri::{
     image::Image,
     menu::{Menu, MenuItem, PredefinedMenuItem},
@@ -17,6 +24,10 @@ const TRAY_SHOW_SETTINGS_ID: &str = "tray-show-settings";
 
 fn app_url() -> WebviewUrl {
     WebviewUrl::App("index.html".into())
+}
+
+fn config_service() -> ConfigService<ProjectPathProvider, KeyringSecretStore> {
+    ConfigService::new(ProjectPathProvider, KeyringSecretStore)
 }
 
 fn bind_hide_on_close(window: &WebviewWindow) {
@@ -161,6 +172,63 @@ async fn read_system_clipboard(
     }
 }
 
+#[tauri::command]
+async fn load_app_config() -> Result<AppConfigRecord, String> {
+    config_service().load().map_err(|error| error.to_string())
+}
+
+#[tauri::command]
+async fn save_app_config(config: AppConfigRecord) -> Result<AppConfigRecord, String> {
+    config_service()
+        .save(config)
+        .map_err(|error| error.to_string())
+}
+
+#[tauri::command]
+async fn upsert_provider_config(provider: ProviderConfigRecord) -> Result<AppConfigRecord, String> {
+    config_service()
+        .upsert_provider(provider)
+        .map_err(|error| error.to_string())
+}
+
+#[tauri::command]
+async fn remove_provider_config(provider_id: String) -> Result<AppConfigRecord, String> {
+    config_service()
+        .remove_provider(&provider_id)
+        .map_err(|error| error.to_string())
+}
+
+#[tauri::command]
+async fn set_active_provider(provider_id: Option<String>) -> Result<AppConfigRecord, String> {
+    config_service()
+        .set_active_provider(provider_id)
+        .map_err(|error| error.to_string())
+}
+
+#[tauri::command]
+async fn set_provider_api_key(
+    provider_id: String,
+    api_key: String,
+) -> Result<ProviderSecretStatus, String> {
+    config_service()
+        .set_provider_secret(&provider_id, &api_key)
+        .map_err(|error| error.to_string())
+}
+
+#[tauri::command]
+async fn get_provider_api_key_status(provider_id: String) -> Result<ProviderSecretStatus, String> {
+    config_service()
+        .get_provider_secret_status(&provider_id)
+        .map_err(|error| error.to_string())
+}
+
+#[tauri::command]
+async fn delete_provider_api_key(provider_id: String) -> Result<ProviderSecretStatus, String> {
+    config_service()
+        .delete_provider_secret(&provider_id)
+        .map_err(|error| error.to_string())
+}
+
 fn build_tray(app: &AppHandle) -> tauri::Result<()> {
     let show_main = MenuItem::with_id(
         app,
@@ -221,7 +289,15 @@ pub fn run() {
             show_translation_popup,
             hide_window,
             toggle_main_window,
-            read_system_clipboard
+            read_system_clipboard,
+            load_app_config,
+            save_app_config,
+            upsert_provider_config,
+            remove_provider_config,
+            set_active_provider,
+            set_provider_api_key,
+            get_provider_api_key_status,
+            delete_provider_api_key
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/apps/desktop/src-tauri/src/models/config.rs
+++ b/apps/desktop/src-tauri/src/models/config.rs
@@ -1,0 +1,269 @@
+use serde::{Deserialize, Serialize};
+
+pub const DEFAULT_DOUBLE_COPY_WINDOW_MS: u64 = 450;
+pub const DEFAULT_TIMEOUT_SECS: u64 = 30;
+pub const DEFAULT_HISTORY_LIMIT: u32 = 100;
+pub const DEFAULT_MAX_TOKENS: u32 = 4_096;
+pub const DEFAULT_PROVIDER_PATH: &str = "/chat/completions";
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "camelCase")]
+pub enum ThemeMode {
+    #[default]
+    System,
+    Light,
+    Dark,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "kebab-case")]
+pub enum ProviderKind {
+    #[default]
+    OpenAiCompatible,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum AuthScheme {
+    #[default]
+    Bearer,
+    None,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct KeyValuePairRecord {
+    pub name: String,
+    pub value: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "kind", rename_all = "lowercase")]
+pub enum LanguageRoutingRuleRecord {
+    Bidirectional {
+        primary_source_language: String,
+        primary_target_languages: Vec<String>,
+        secondary_source_language: String,
+        secondary_target_languages: Vec<String>,
+    },
+    Branching {
+        english_source_language: String,
+        english_target_languages: Vec<String>,
+        chinese_source_language: String,
+        chinese_target_languages: Vec<String>,
+        fallback_target_languages: Vec<String>,
+    },
+    Fixed {
+        target_languages: Vec<String>,
+    },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct UiConfigRecord {
+    pub theme_mode: ThemeMode,
+    pub show_tray_icon: bool,
+}
+
+impl Default for UiConfigRecord {
+    fn default() -> Self {
+        Self {
+            theme_mode: ThemeMode::System,
+            show_tray_icon: true,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct TriggerConfigRecord {
+    pub double_copy_window_ms: u64,
+    pub fallback_shortcut: String,
+    pub replace_popup_on_new_trigger: bool,
+}
+
+impl Default for TriggerConfigRecord {
+    fn default() -> Self {
+        Self {
+            double_copy_window_ms: DEFAULT_DOUBLE_COPY_WINDOW_MS,
+            fallback_shortcut: "CmdOrCtrl+Shift+Y".to_string(),
+            replace_popup_on_new_trigger: true,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct TranslationConfigRecord {
+    pub routing_rule: LanguageRoutingRuleRecord,
+    pub user_rules: Option<String>,
+    pub preserve_paragraphs: bool,
+}
+
+impl Default for TranslationConfigRecord {
+    fn default() -> Self {
+        Self {
+            routing_rule: LanguageRoutingRuleRecord::Branching {
+                english_source_language: "en".to_string(),
+                english_target_languages: vec!["zh-CN".to_string()],
+                chinese_source_language: "zh-CN".to_string(),
+                chinese_target_languages: vec!["en".to_string()],
+                fallback_target_languages: vec!["en".to_string(), "zh-CN".to_string()],
+            },
+            user_rules: None,
+            preserve_paragraphs: true,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct HistoryConfigRecord {
+    pub enabled: bool,
+    pub max_items: u32,
+    pub store_full_text: bool,
+}
+
+impl Default for HistoryConfigRecord {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            max_items: DEFAULT_HISTORY_LIMIT,
+            store_full_text: false,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct DebugConfigRecord {
+    pub enabled: bool,
+    pub log_raw_network_errors: bool,
+}
+
+impl Default for DebugConfigRecord {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            log_raw_network_errors: false,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct ProviderConfigRecord {
+    pub id: String,
+    pub name: String,
+    pub kind: ProviderKind,
+    pub base_url: String,
+    pub path: String,
+    pub auth_scheme: AuthScheme,
+    pub api_key_ref: Option<String>,
+    pub organization: Option<String>,
+    pub model: String,
+    pub temperature: f64,
+    pub top_p: f64,
+    pub max_tokens: Option<u32>,
+    pub timeout_secs: u64,
+    pub custom_headers: Vec<KeyValuePairRecord>,
+    pub enabled: bool,
+}
+
+impl Default for ProviderConfigRecord {
+    fn default() -> Self {
+        Self {
+            id: "provider-default".to_string(),
+            name: "OpenAI-compatible".to_string(),
+            kind: ProviderKind::OpenAiCompatible,
+            base_url: String::new(),
+            path: DEFAULT_PROVIDER_PATH.to_string(),
+            auth_scheme: AuthScheme::Bearer,
+            api_key_ref: None,
+            organization: None,
+            model: String::new(),
+            temperature: 0.2,
+            top_p: 1.0,
+            max_tokens: Some(DEFAULT_MAX_TOKENS),
+            timeout_secs: DEFAULT_TIMEOUT_SECS,
+            custom_headers: Vec::new(),
+            enabled: true,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct AppConfigRecord {
+    pub schema_version: u32,
+    pub ui: UiConfigRecord,
+    pub trigger: TriggerConfigRecord,
+    pub providers: Vec<ProviderConfigRecord>,
+    pub active_provider_id: Option<String>,
+    pub translation: TranslationConfigRecord,
+    pub history: HistoryConfigRecord,
+    pub debug: DebugConfigRecord,
+}
+
+impl Default for AppConfigRecord {
+    fn default() -> Self {
+        Self {
+            schema_version: 1,
+            ui: UiConfigRecord::default(),
+            trigger: TriggerConfigRecord::default(),
+            providers: Vec::new(),
+            active_provider_id: None,
+            translation: TranslationConfigRecord::default(),
+            history: HistoryConfigRecord::default(),
+            debug: DebugConfigRecord::default(),
+        }
+    }
+}
+
+impl AppConfigRecord {
+    pub fn normalize(mut self) -> Self {
+        self.schema_version = 1;
+        self.providers = normalize_provider_list(self.providers);
+
+        self.active_provider_id = self.active_provider_id.filter(|provider_id| {
+            self.providers
+                .iter()
+                .any(|provider| provider.id == *provider_id)
+        });
+
+        self
+    }
+}
+
+fn normalize_provider_list(providers: Vec<ProviderConfigRecord>) -> Vec<ProviderConfigRecord> {
+    let mut seen = std::collections::BTreeSet::new();
+
+    providers
+        .into_iter()
+        .map(normalize_provider)
+        .filter(|provider| seen.insert(provider.id.clone()))
+        .collect()
+}
+
+fn normalize_provider(mut provider: ProviderConfigRecord) -> ProviderConfigRecord {
+    provider.id = provider.id.trim().to_string();
+    provider.name = provider.name.trim().to_string();
+    provider.base_url = provider.base_url.trim().to_string();
+    provider.path = if provider.path.trim().is_empty() {
+        DEFAULT_PROVIDER_PATH.to_string()
+    } else {
+        provider.path.trim().to_string()
+    };
+    provider.organization = provider.organization.map(|value| value.trim().to_string());
+    provider.model = provider.model.trim().to_string();
+    provider.custom_headers = provider
+        .custom_headers
+        .into_iter()
+        .map(|header| KeyValuePairRecord {
+            name: header.name.trim().to_string(),
+            value: header.value.trim().to_string(),
+        })
+        .collect();
+
+    provider
+}

--- a/apps/desktop/src-tauri/src/models/mod.rs
+++ b/apps/desktop/src-tauri/src/models/mod.rs
@@ -1,0 +1,1 @@
+pub mod config;

--- a/apps/desktop/src-tauri/src/services/config.rs
+++ b/apps/desktop/src-tauri/src/services/config.rs
@@ -1,0 +1,425 @@
+use std::{
+    fs,
+    io::Write,
+    path::{Path, PathBuf},
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+use serde::Serialize;
+
+use crate::{
+    models::config::{AppConfigRecord, ProviderConfigRecord},
+    storage::{fs_paths::ConfigPathProvider, secure_storage::SecretStore},
+};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ProviderSecretStatus {
+    pub provider_id: String,
+    pub has_secret: bool,
+}
+
+#[derive(Debug)]
+pub enum ConfigServiceError {
+    ConfigPathUnavailable,
+    Io(String),
+    Serialize(String),
+    SecretStore(String),
+    ProviderNotFound(String),
+    InvalidProviderId,
+}
+
+impl std::fmt::Display for ConfigServiceError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::ConfigPathUnavailable => f.write_str("config path is unavailable"),
+            Self::Io(error) => write!(f, "config I/O failed: {error}"),
+            Self::Serialize(error) => write!(f, "config serialization failed: {error}"),
+            Self::SecretStore(error) => write!(f, "secure storage failed: {error}"),
+            Self::ProviderNotFound(provider_id) => {
+                write!(f, "provider not found: {provider_id}")
+            }
+            Self::InvalidProviderId => f.write_str("provider id must not be empty"),
+        }
+    }
+}
+
+impl std::error::Error for ConfigServiceError {}
+
+pub struct ConfigService<P, S> {
+    path_provider: P,
+    secret_store: S,
+}
+
+impl<P, S> ConfigService<P, S>
+where
+    P: ConfigPathProvider,
+    S: SecretStore,
+{
+    pub fn new(path_provider: P, secret_store: S) -> Self {
+        Self {
+            path_provider,
+            secret_store,
+        }
+    }
+
+    pub fn load(&self) -> Result<AppConfigRecord, ConfigServiceError> {
+        let path = self.path_provider.config_path()?;
+        self.load_from_path(&path)
+    }
+
+    pub fn save(&self, config: AppConfigRecord) -> Result<AppConfigRecord, ConfigServiceError> {
+        let normalized = config.normalize();
+        let path = self.path_provider.config_path()?;
+        self.write_config(&path, &normalized)?;
+        Ok(normalized)
+    }
+
+    pub fn upsert_provider(
+        &self,
+        provider: ProviderConfigRecord,
+    ) -> Result<AppConfigRecord, ConfigServiceError> {
+        let provider_id = provider.id.trim().to_string();
+        if provider_id.is_empty() {
+            return Err(ConfigServiceError::InvalidProviderId);
+        }
+
+        let mut config = self.load()?;
+        if let Some(existing) = config
+            .providers
+            .iter_mut()
+            .find(|existing| existing.id == provider_id)
+        {
+            let api_key_ref = existing.api_key_ref.clone();
+            *existing = provider;
+            existing.api_key_ref = existing.api_key_ref.clone().or(api_key_ref);
+        } else {
+            config.providers.push(provider);
+        }
+
+        self.save(config)
+    }
+
+    pub fn remove_provider(
+        &self,
+        provider_id: &str,
+    ) -> Result<AppConfigRecord, ConfigServiceError> {
+        let mut config = self.load()?;
+        if let Some(position) = config
+            .providers
+            .iter()
+            .position(|provider| provider.id == provider_id)
+        {
+            if let Some(secret_ref) = config.providers[position].api_key_ref.clone() {
+                self.secret_store.delete_secret(&secret_ref)?;
+            }
+
+            config.providers.remove(position);
+            if config.active_provider_id.as_deref() == Some(provider_id) {
+                config.active_provider_id = None;
+            }
+
+            self.save(config)
+        } else {
+            Err(ConfigServiceError::ProviderNotFound(
+                provider_id.to_string(),
+            ))
+        }
+    }
+
+    pub fn set_active_provider(
+        &self,
+        provider_id: Option<String>,
+    ) -> Result<AppConfigRecord, ConfigServiceError> {
+        let mut config = self.load()?;
+
+        if let Some(provider_id) = provider_id {
+            if !config
+                .providers
+                .iter()
+                .any(|provider| provider.id == provider_id)
+            {
+                return Err(ConfigServiceError::ProviderNotFound(provider_id));
+            }
+            config.active_provider_id = Some(provider_id);
+        } else {
+            config.active_provider_id = None;
+        }
+
+        self.save(config)
+    }
+
+    pub fn set_provider_secret(
+        &self,
+        provider_id: &str,
+        api_key: &str,
+    ) -> Result<ProviderSecretStatus, ConfigServiceError> {
+        let mut config = self.load()?;
+        let provider = config
+            .providers
+            .iter_mut()
+            .find(|provider| provider.id == provider_id)
+            .ok_or_else(|| ConfigServiceError::ProviderNotFound(provider_id.to_string()))?;
+
+        let secret_ref = provider
+            .api_key_ref
+            .clone()
+            .unwrap_or_else(|| format!("provider/{provider_id}"));
+        self.secret_store.set_secret(&secret_ref, api_key)?;
+        provider.api_key_ref = Some(secret_ref);
+        self.save(config)?;
+
+        Ok(ProviderSecretStatus {
+            provider_id: provider_id.to_string(),
+            has_secret: true,
+        })
+    }
+
+    pub fn get_provider_secret_status(
+        &self,
+        provider_id: &str,
+    ) -> Result<ProviderSecretStatus, ConfigServiceError> {
+        let config = self.load()?;
+        let provider = config
+            .providers
+            .iter()
+            .find(|provider| provider.id == provider_id)
+            .ok_or_else(|| ConfigServiceError::ProviderNotFound(provider_id.to_string()))?;
+
+        let has_secret = if let Some(secret_ref) = provider.api_key_ref.as_deref() {
+            self.secret_store.get_secret(secret_ref)?.is_some()
+        } else {
+            false
+        };
+
+        Ok(ProviderSecretStatus {
+            provider_id: provider_id.to_string(),
+            has_secret,
+        })
+    }
+
+    pub fn delete_provider_secret(
+        &self,
+        provider_id: &str,
+    ) -> Result<ProviderSecretStatus, ConfigServiceError> {
+        let mut config = self.load()?;
+        let provider = config
+            .providers
+            .iter_mut()
+            .find(|provider| provider.id == provider_id)
+            .ok_or_else(|| ConfigServiceError::ProviderNotFound(provider_id.to_string()))?;
+
+        if let Some(secret_ref) = provider.api_key_ref.as_deref() {
+            self.secret_store.delete_secret(secret_ref)?;
+        }
+
+        provider.api_key_ref = None;
+        self.save(config)?;
+
+        Ok(ProviderSecretStatus {
+            provider_id: provider_id.to_string(),
+            has_secret: false,
+        })
+    }
+
+    fn load_from_path(&self, path: &Path) -> Result<AppConfigRecord, ConfigServiceError> {
+        if !path.exists() {
+            return Ok(AppConfigRecord::default());
+        }
+
+        let raw =
+            fs::read_to_string(path).map_err(|error| ConfigServiceError::Io(error.to_string()))?;
+        match toml::from_str::<AppConfigRecord>(&raw) {
+            Ok(config) => Ok(config.normalize()),
+            Err(_) => Ok(AppConfigRecord::default()),
+        }
+    }
+
+    fn write_config(
+        &self,
+        path: &Path,
+        config: &AppConfigRecord,
+    ) -> Result<(), ConfigServiceError> {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)
+                .map_err(|error| ConfigServiceError::Io(error.to_string()))?;
+        }
+
+        let serialized = toml::to_string_pretty(config)
+            .map_err(|error| ConfigServiceError::Serialize(error.to_string()))?;
+
+        let temp_path = temporary_path(path);
+        let mut file = fs::File::create(&temp_path)
+            .map_err(|error| ConfigServiceError::Io(error.to_string()))?;
+        file.write_all(serialized.as_bytes())
+            .map_err(|error| ConfigServiceError::Io(error.to_string()))?;
+        file.sync_all()
+            .map_err(|error| ConfigServiceError::Io(error.to_string()))?;
+        fs::rename(&temp_path, path).map_err(|error| ConfigServiceError::Io(error.to_string()))
+    }
+}
+
+fn temporary_path(path: &Path) -> PathBuf {
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_nanos())
+        .unwrap_or_default();
+
+    path.with_extension(format!("tmp-{nonce}.toml"))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        collections::BTreeMap,
+        path::PathBuf,
+        sync::{Arc, Mutex},
+    };
+
+    use super::*;
+    use crate::{
+        models::config::{AppConfigRecord, ProviderConfigRecord},
+        storage::fs_paths::ConfigPathProvider,
+    };
+
+    #[derive(Clone)]
+    struct FixedPathProvider {
+        path: PathBuf,
+    }
+
+    impl ConfigPathProvider for FixedPathProvider {
+        fn config_path(&self) -> Result<PathBuf, ConfigServiceError> {
+            Ok(self.path.clone())
+        }
+    }
+
+    #[derive(Clone, Default)]
+    struct InMemorySecretStore {
+        values: Arc<Mutex<BTreeMap<String, String>>>,
+    }
+
+    impl SecretStore for InMemorySecretStore {
+        fn set_secret(&self, key: &str, secret: &str) -> Result<(), ConfigServiceError> {
+            self.values
+                .lock()
+                .expect("secret store lock")
+                .insert(key.to_string(), secret.to_string());
+            Ok(())
+        }
+
+        fn get_secret(&self, key: &str) -> Result<Option<String>, ConfigServiceError> {
+            Ok(self
+                .values
+                .lock()
+                .expect("secret store lock")
+                .get(key)
+                .cloned())
+        }
+
+        fn delete_secret(&self, key: &str) -> Result<(), ConfigServiceError> {
+            self.values.lock().expect("secret store lock").remove(key);
+            Ok(())
+        }
+    }
+
+    fn service() -> (
+        ConfigService<FixedPathProvider, InMemorySecretStore>,
+        PathBuf,
+        InMemorySecretStore,
+    ) {
+        let temp_dir = std::env::temp_dir().join(format!(
+            "cliplingo-config-test-{}",
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("time")
+                .as_nanos()
+        ));
+        let config_path = temp_dir.join("config.toml");
+        let secret_store = InMemorySecretStore::default();
+        (
+            ConfigService::new(
+                FixedPathProvider {
+                    path: config_path.clone(),
+                },
+                secret_store.clone(),
+            ),
+            config_path,
+            secret_store,
+        )
+    }
+
+    #[test]
+    fn load_missing_config_returns_defaults() {
+        let (service, _, _) = service();
+        let config = service.load().expect("default config");
+        assert_eq!(config, AppConfigRecord::default());
+    }
+
+    #[test]
+    fn load_corrupted_config_returns_defaults() {
+        let (service, config_path, _) = service();
+        fs::create_dir_all(config_path.parent().expect("parent")).expect("mkdir");
+        fs::write(&config_path, "not = { valid toml").expect("write corrupted config");
+
+        let config = service.load().expect("default config after corruption");
+        assert_eq!(config, AppConfigRecord::default());
+    }
+
+    #[test]
+    fn provider_management_updates_config_without_plaintext_secrets() {
+        let (service, config_path, secret_store) = service();
+        let provider = ProviderConfigRecord {
+            id: "provider-one".to_string(),
+            name: "Provider One".to_string(),
+            ..ProviderConfigRecord::default()
+        };
+
+        let config = service.upsert_provider(provider).expect("insert provider");
+        assert_eq!(config.providers.len(), 1);
+
+        let status = service
+            .set_provider_secret("provider-one", "super-secret-key")
+            .expect("store secret");
+        assert!(status.has_secret);
+
+        let serialized = fs::read_to_string(config_path).expect("config contents");
+        assert!(!serialized.contains("super-secret-key"));
+        assert!(serialized.contains("provider-one"));
+        assert_eq!(
+            secret_store
+                .get_secret("provider/provider-one")
+                .expect("secret lookup"),
+            Some("super-secret-key".to_string())
+        );
+    }
+
+    #[test]
+    fn removing_provider_also_removes_secret_and_active_provider() {
+        let (service, _, secret_store) = service();
+        let provider = ProviderConfigRecord {
+            id: "provider-one".to_string(),
+            name: "Provider One".to_string(),
+            ..ProviderConfigRecord::default()
+        };
+        service.upsert_provider(provider).expect("insert provider");
+        service
+            .set_provider_secret("provider-one", "secret")
+            .expect("store secret");
+        service
+            .set_active_provider(Some("provider-one".to_string()))
+            .expect("activate provider");
+
+        let config = service
+            .remove_provider("provider-one")
+            .expect("remove provider");
+
+        assert!(config.providers.is_empty());
+        assert_eq!(config.active_provider_id, None);
+        assert_eq!(
+            secret_store
+                .get_secret("provider/provider-one")
+                .expect("secret lookup"),
+            None
+        );
+    }
+}

--- a/apps/desktop/src-tauri/src/services/mod.rs
+++ b/apps/desktop/src-tauri/src/services/mod.rs
@@ -1,1 +1,2 @@
 pub mod clipboard;
+pub mod config;

--- a/apps/desktop/src-tauri/src/storage/fs_paths.rs
+++ b/apps/desktop/src-tauri/src/storage/fs_paths.rs
@@ -1,0 +1,25 @@
+use std::path::PathBuf;
+
+use directories::ProjectDirs;
+
+use crate::services::config::ConfigServiceError;
+
+const QUALIFIER: &str = "com";
+const ORGANIZATION: &str = "brucekz";
+const APPLICATION: &str = "cliplingo";
+
+pub trait ConfigPathProvider {
+    fn config_path(&self) -> Result<PathBuf, ConfigServiceError>;
+}
+
+#[derive(Debug, Default, Clone, Copy)]
+pub struct ProjectPathProvider;
+
+impl ConfigPathProvider for ProjectPathProvider {
+    fn config_path(&self) -> Result<PathBuf, ConfigServiceError> {
+        let project_dirs = ProjectDirs::from(QUALIFIER, ORGANIZATION, APPLICATION)
+            .ok_or(ConfigServiceError::ConfigPathUnavailable)?;
+
+        Ok(project_dirs.config_dir().join("config.toml"))
+    }
+}

--- a/apps/desktop/src-tauri/src/storage/mod.rs
+++ b/apps/desktop/src-tauri/src/storage/mod.rs
@@ -1,0 +1,2 @@
+pub mod fs_paths;
+pub mod secure_storage;

--- a/apps/desktop/src-tauri/src/storage/secure_storage.rs
+++ b/apps/desktop/src-tauri/src/storage/secure_storage.rs
@@ -1,0 +1,44 @@
+use keyring::{Entry, Error as KeyringError};
+
+use crate::services::config::ConfigServiceError;
+
+const SERVICE_NAME: &str = "com.brucekz.cliplingo";
+
+pub trait SecretStore {
+    fn set_secret(&self, key: &str, secret: &str) -> Result<(), ConfigServiceError>;
+    fn get_secret(&self, key: &str) -> Result<Option<String>, ConfigServiceError>;
+    fn delete_secret(&self, key: &str) -> Result<(), ConfigServiceError>;
+}
+
+#[derive(Debug, Default, Clone, Copy)]
+pub struct KeyringSecretStore;
+
+impl KeyringSecretStore {
+    fn entry(&self, key: &str) -> Result<Entry, ConfigServiceError> {
+        Entry::new(SERVICE_NAME, key)
+            .map_err(|error| ConfigServiceError::SecretStore(error.to_string()))
+    }
+}
+
+impl SecretStore for KeyringSecretStore {
+    fn set_secret(&self, key: &str, secret: &str) -> Result<(), ConfigServiceError> {
+        self.entry(key)?
+            .set_password(secret)
+            .map_err(|error| ConfigServiceError::SecretStore(error.to_string()))
+    }
+
+    fn get_secret(&self, key: &str) -> Result<Option<String>, ConfigServiceError> {
+        match self.entry(key)?.get_password() {
+            Ok(secret) => Ok(Some(secret)),
+            Err(KeyringError::NoEntry) => Ok(None),
+            Err(error) => Err(ConfigServiceError::SecretStore(error.to_string())),
+        }
+    }
+
+    fn delete_secret(&self, key: &str) -> Result<(), ConfigServiceError> {
+        match self.entry(key)?.delete_credential() {
+            Ok(()) | Err(KeyringError::NoEntry) => Ok(()),
+            Err(error) => Err(ConfigServiceError::SecretStore(error.to_string())),
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add Rust-side app config models, filesystem path resolution, and TOML persistence for `config.toml`
- add secure API key storage with `keyring` and provider management commands that keep secrets out of plain config files
- add tests for default fallback, corruption recovery, and secret redaction from persisted config

## Validation
- `cargo fmt --manifest-path src-tauri/Cargo.toml`
- `cargo test --manifest-path src-tauri/Cargo.toml config`
- `cargo check --manifest-path src-tauri/Cargo.toml`

Refs #4
