### PR TITLE
feat(provider): add provider abstraction and OpenAI-compatible provider

### DIFF
--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -472,6 +472,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -496,15 +502,19 @@ dependencies = [
 name = "cliplingo-desktop"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "directories",
  "keyring",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "tauri",
  "tauri-build",
  "tauri-plugin-clipboard-manager",
  "tauri-plugin-opener",
+ "tokio",
  "toml 0.8.2",
+ "url",
 ]
 
 [[package]]
@@ -1395,8 +1405,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1406,9 +1418,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1707,6 +1721,23 @@ dependencies = [
  "smallvec",
  "tokio",
  "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -2197,6 +2228,12 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "mac"
@@ -3054,6 +3091,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.2",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3100,6 +3192,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3120,6 +3222,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3135,6 +3247,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -3232,6 +3353,44 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+]
+
+[[package]]
+name = "reqwest"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
@@ -3265,6 +3424,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3293,10 +3466,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.23.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+dependencies = [
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "same-file"
@@ -3540,6 +3754,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -3791,6 +4017,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "swift-rs"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3942,7 +4174,7 @@ dependencies = [
  "percent-encoding",
  "plist",
  "raw-window-handle",
- "reqwest",
+ "reqwest 0.13.2",
  "serde",
  "serde_json",
  "serde_repr",
@@ -4310,6 +4542,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tokio"
 version = "1.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4320,7 +4567,29 @@ dependencies = [
  "mio",
  "pin-project-lite",
  "socket2",
+ "tokio-macros",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
 ]
 
 [[package]]
@@ -4639,6 +4908,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4951,6 +5226,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "web_atoms"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5004,6 +5289,15 @@ dependencies = [
  "pkg-config",
  "soup3-sys",
  "system-deps",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -5240,6 +5534,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
  "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -18,6 +18,8 @@ crate-type = ["staticlib", "cdylib", "rlib"]
 tauri-build = { version = "2", features = [] }
 
 [dependencies]
+async-trait = "0.1"
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 tauri = { version = "2", features = ["tray-icon", "image-png"] }
 tauri-plugin-opener = "2"
 tauri-plugin-clipboard-manager = "2"
@@ -26,3 +28,7 @@ keyring = { version = "3", features = ["apple-native", "windows-native", "sync-s
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 toml = "0.8"
+url = "2"
+
+[dev-dependencies]
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }

--- a/apps/desktop/src-tauri/src/models/config.rs
+++ b/apps/desktop/src-tauri/src/models/config.rs
@@ -6,7 +6,7 @@ pub const DEFAULT_HISTORY_LIMIT: u32 = 100;
 pub const DEFAULT_MAX_TOKENS: u32 = 4_096;
 pub const DEFAULT_PROVIDER_PATH: &str = "/chat/completions";
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
 #[serde(rename_all = "camelCase")]
 pub enum ThemeMode {
     #[default]
@@ -15,14 +15,14 @@ pub enum ThemeMode {
     Dark,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
 #[serde(rename_all = "kebab-case")]
 pub enum ProviderKind {
     #[default]
     OpenAiCompatible,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
 #[serde(rename_all = "lowercase")]
 pub enum AuthScheme {
     #[default]

--- a/apps/desktop/src-tauri/src/services/mod.rs
+++ b/apps/desktop/src-tauri/src/services/mod.rs
@@ -1,2 +1,3 @@
 pub mod clipboard;
 pub mod config;
+pub mod provider;

--- a/apps/desktop/src-tauri/src/services/provider/mod.rs
+++ b/apps/desktop/src-tauri/src/services/provider/mod.rs
@@ -1,0 +1,157 @@
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+
+pub mod openai_compatible;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ChatRole {
+    System,
+    User,
+    Assistant,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ChatMessage {
+    pub role: ChatRole,
+    pub content: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct ProviderRequest {
+    pub request_id: Option<String>,
+    pub model: Option<String>,
+    pub messages: Vec<ChatMessage>,
+    pub temperature: Option<f64>,
+    pub top_p: Option<f64>,
+    pub max_tokens: Option<u32>,
+    pub timeout_secs: Option<u64>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct ProviderUsage {
+    pub prompt_tokens: Option<u32>,
+    pub completion_tokens: Option<u32>,
+    pub total_tokens: Option<u32>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ProviderResponse {
+    pub request_id: Option<String>,
+    pub provider_id: String,
+    pub provider_name: String,
+    pub model: String,
+    pub content: String,
+    pub latency_ms: u64,
+    pub finish_reason: Option<String>,
+    pub usage: Option<ProviderUsage>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ProviderErrorCode {
+    InvalidBaseUrl,
+    InvalidEndpointPath,
+    InvalidHeaderName,
+    InvalidHeaderValue,
+    InvalidHeaderOverride,
+    InvalidProviderId,
+    MissingApiKey,
+    MissingModel,
+    InvalidTemperature,
+    InvalidTopP,
+    InvalidMaxTokens,
+    InvalidTimeout,
+    UnsupportedAuthScheme,
+    RequestBuildFailed,
+    RequestFailed,
+    HttpStatus,
+    ResponseParseFailed,
+    EmptyResponse,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ProviderError {
+    pub provider_id: String,
+    pub code: ProviderErrorCode,
+    pub message: String,
+    pub status: Option<u16>,
+    pub details: Option<String>,
+}
+
+impl ProviderError {
+    pub fn new(
+        provider_id: impl Into<String>,
+        code: ProviderErrorCode,
+        message: impl Into<String>,
+    ) -> Self {
+        Self {
+            provider_id: provider_id.into(),
+            code,
+            message: message.into(),
+            status: None,
+            details: None,
+        }
+    }
+
+    pub fn with_status(mut self, status: u16) -> Self {
+        self.status = Some(status);
+        self
+    }
+
+    pub fn with_details(mut self, details: impl Into<String>) -> Self {
+        self.details = Some(details.into());
+        self
+    }
+}
+
+impl std::fmt::Display for ProviderError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self.status {
+            Some(status) => write!(
+                f,
+                "{} (status {status}): {}",
+                self.code_string(),
+                self.message
+            ),
+            None => write!(f, "{}: {}", self.code_string(), self.message),
+        }
+    }
+}
+
+impl ProviderError {
+    fn code_string(&self) -> &'static str {
+        match self.code {
+            ProviderErrorCode::InvalidBaseUrl => "invalid_base_url",
+            ProviderErrorCode::InvalidEndpointPath => "invalid_endpoint_path",
+            ProviderErrorCode::InvalidHeaderName => "invalid_header_name",
+            ProviderErrorCode::InvalidHeaderValue => "invalid_header_value",
+            ProviderErrorCode::InvalidHeaderOverride => "invalid_header_override",
+            ProviderErrorCode::InvalidProviderId => "invalid_provider_id",
+            ProviderErrorCode::MissingApiKey => "missing_api_key",
+            ProviderErrorCode::MissingModel => "missing_model",
+            ProviderErrorCode::InvalidTemperature => "invalid_temperature",
+            ProviderErrorCode::InvalidTopP => "invalid_top_p",
+            ProviderErrorCode::InvalidMaxTokens => "invalid_max_tokens",
+            ProviderErrorCode::InvalidTimeout => "invalid_timeout",
+            ProviderErrorCode::UnsupportedAuthScheme => "unsupported_auth_scheme",
+            ProviderErrorCode::RequestBuildFailed => "request_build_failed",
+            ProviderErrorCode::RequestFailed => "request_failed",
+            ProviderErrorCode::HttpStatus => "http_status",
+            ProviderErrorCode::ResponseParseFailed => "response_parse_failed",
+            ProviderErrorCode::EmptyResponse => "empty_response",
+        }
+    }
+}
+
+impl std::error::Error for ProviderError {}
+
+#[async_trait]
+pub trait TranslationProvider: Send + Sync {
+    async fn translate(&self, request: ProviderRequest) -> Result<ProviderResponse, ProviderError>;
+}

--- a/apps/desktop/src-tauri/src/services/provider/openai_compatible.rs
+++ b/apps/desktop/src-tauri/src/services/provider/openai_compatible.rs
@@ -1,0 +1,854 @@
+use std::{
+    collections::HashSet,
+    time::{Duration, Instant},
+};
+
+use reqwest::{
+    header::{HeaderMap, HeaderName, HeaderValue},
+    Client,
+};
+use serde::{Deserialize, Serialize};
+use url::Url;
+
+use crate::models::config::{AuthScheme, KeyValuePairRecord, ProviderConfigRecord};
+
+use super::{
+    ChatMessage, ProviderError, ProviderErrorCode, ProviderRequest, ProviderResponse,
+    ProviderUsage, TranslationProvider,
+};
+
+const DEFAULT_CHAT_COMPLETIONS_PATH: &str = "/chat/completions";
+const OPENAI_ORGANIZATION_HEADER: &str = "OpenAI-Organization";
+const MIN_TIMEOUT_SECS: u64 = 3;
+const MAX_TIMEOUT_SECS: u64 = 120;
+const MIN_TEMPERATURE: f64 = 0.0;
+const MAX_TEMPERATURE: f64 = 2.0;
+const MIN_TOP_P: f64 = 0.0;
+const MAX_TOP_P: f64 = 1.0;
+
+#[derive(Debug, Clone)]
+pub struct OpenAiCompatibleProvider {
+    provider_id: String,
+    provider_name: String,
+    endpoint: Url,
+    auth_scheme: AuthScheme,
+    api_key: Option<String>,
+    organization: Option<String>,
+    default_model: Option<String>,
+    default_temperature: f64,
+    default_top_p: f64,
+    default_max_tokens: Option<u32>,
+    default_timeout_secs: u64,
+    custom_headers: HeaderMap,
+    client: Client,
+}
+
+impl OpenAiCompatibleProvider {
+    pub fn try_from_config(
+        config: ProviderConfigRecord,
+        api_key: Option<String>,
+    ) -> Result<Self, ProviderError> {
+        let provider_id = normalized_provider_id(&config.id)?;
+        let provider_name = normalized_name(&config.name, &provider_id);
+        let endpoint = build_endpoint(&provider_id, &config.base_url, &config.path)?;
+        let custom_headers = build_custom_headers(&provider_id, &config.custom_headers)?;
+        let default_model = normalized_optional_string(&config.model);
+        let default_temperature = validate_temperature(&provider_id, config.temperature)?;
+        let default_top_p = validate_top_p(&provider_id, config.top_p)?;
+        let default_max_tokens = config.max_tokens;
+        let default_timeout_secs = validate_timeout_secs(&provider_id, config.timeout_secs)?;
+        let client = Client::builder().build().map_err(|error| {
+            provider_error(
+                &provider_id,
+                ProviderErrorCode::RequestBuildFailed,
+                "failed to build reqwest client",
+            )
+            .with_details(error.to_string())
+        })?;
+
+        Ok(Self {
+            provider_id,
+            provider_name,
+            endpoint,
+            auth_scheme: config.auth_scheme,
+            api_key: api_key.filter(|value| !value.trim().is_empty()),
+            organization: normalized_optional_string_option(config.organization),
+            default_model,
+            default_temperature,
+            default_top_p,
+            default_max_tokens,
+            default_timeout_secs,
+            custom_headers,
+            client,
+        })
+    }
+
+    pub fn endpoint(&self) -> &Url {
+        &self.endpoint
+    }
+
+    pub fn provider_id(&self) -> &str {
+        &self.provider_id
+    }
+
+    fn resolve_settings(
+        &self,
+        request: &ProviderRequest,
+    ) -> Result<ResolvedRequestSettings, ProviderError> {
+        let model = request
+            .model
+            .as_deref()
+            .and_then(non_empty_string)
+            .or_else(|| self.default_model.as_deref())
+            .ok_or_else(|| {
+                provider_error(
+                    &self.provider_id,
+                    ProviderErrorCode::MissingModel,
+                    "model is required",
+                )
+            })?
+            .to_string();
+
+        let temperature = validate_temperature(
+            &self.provider_id,
+            request.temperature.unwrap_or(self.default_temperature),
+        )?;
+        let top_p = validate_top_p(
+            &self.provider_id,
+            request.top_p.unwrap_or(self.default_top_p),
+        )?;
+        let max_tokens = match request.max_tokens.or(self.default_max_tokens) {
+            Some(value) => Some(validate_max_tokens(&self.provider_id, value)?),
+            None => None,
+        };
+        let timeout_secs = validate_timeout_secs(
+            &self.provider_id,
+            request.timeout_secs.unwrap_or(self.default_timeout_secs),
+        )?;
+
+        Ok(ResolvedRequestSettings {
+            model,
+            temperature,
+            top_p,
+            max_tokens,
+            timeout_secs,
+        })
+    }
+
+    fn build_request_body(
+        &self,
+        request: &ProviderRequest,
+        settings: &ResolvedRequestSettings,
+    ) -> OpenAiChatCompletionRequest {
+        OpenAiChatCompletionRequest {
+            model: settings.model.clone(),
+            messages: request.messages.clone(),
+            temperature: settings.temperature,
+            top_p: settings.top_p,
+            max_tokens: settings.max_tokens,
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl TranslationProvider for OpenAiCompatibleProvider {
+    async fn translate(&self, request: ProviderRequest) -> Result<ProviderResponse, ProviderError> {
+        if request.messages.is_empty() {
+            return Err(provider_error(
+                &self.provider_id,
+                ProviderErrorCode::RequestBuildFailed,
+                "at least one chat message is required",
+            ));
+        }
+
+        let settings = self.resolve_settings(&request)?;
+        let request_body = self.build_request_body(&request, &settings);
+        let mut http_request = self.client.post(self.endpoint.clone()).json(&request_body);
+        http_request = http_request.timeout(Duration::from_secs(settings.timeout_secs));
+
+        http_request = match self.auth_scheme {
+            AuthScheme::Bearer => {
+                let api_key = self.api_key.as_deref().ok_or_else(|| {
+                    provider_error(
+                        &self.provider_id,
+                        ProviderErrorCode::MissingApiKey,
+                        "bearer auth requires an API key",
+                    )
+                })?;
+                http_request.bearer_auth(api_key)
+            }
+            AuthScheme::None => http_request,
+        };
+
+        if let Some(organization) = self.organization.as_deref() {
+            http_request = http_request.header(OPENAI_ORGANIZATION_HEADER, organization);
+        }
+
+        for (name, value) in &self.custom_headers {
+            http_request = http_request.header(name, value);
+        }
+
+        let started_at = Instant::now();
+        let response = http_request.send().await.map_err(|error| {
+            provider_error(
+                &self.provider_id,
+                ProviderErrorCode::RequestFailed,
+                "request failed",
+            )
+            .with_details(error.to_string())
+        })?;
+
+        let latency_ms = started_at.elapsed().as_millis() as u64;
+        let status = response.status();
+        let response_text = response.text().await.map_err(|error| {
+            provider_error(
+                &self.provider_id,
+                ProviderErrorCode::ResponseParseFailed,
+                "failed to read provider response",
+            )
+            .with_details(error.to_string())
+        })?;
+
+        if !status.is_success() {
+            return Err(provider_error(
+                &self.provider_id,
+                ProviderErrorCode::HttpStatus,
+                format!("provider returned HTTP {status}"),
+            )
+            .with_status(status.as_u16())
+            .with_details(response_text));
+        }
+
+        let parsed: OpenAiChatCompletionResponse =
+            serde_json::from_str(&response_text).map_err(|error| {
+                provider_error(
+                    &self.provider_id,
+                    ProviderErrorCode::ResponseParseFailed,
+                    "failed to parse OpenAI-compatible response",
+                )
+                .with_details(error.to_string())
+            })?;
+
+        let choice = parsed.choices.into_iter().find_map(|choice| {
+            choice
+                .message
+                .content
+                .map(|content| (content, choice.finish_reason))
+        });
+
+        let Some((content, finish_reason)) = choice else {
+            return Err(provider_error(
+                &self.provider_id,
+                ProviderErrorCode::EmptyResponse,
+                "provider response did not contain translated text",
+            ));
+        };
+
+        let content = content.trim().to_string();
+        if content.is_empty() {
+            return Err(provider_error(
+                &self.provider_id,
+                ProviderErrorCode::EmptyResponse,
+                "provider response contained empty content",
+            ));
+        }
+
+        Ok(ProviderResponse {
+            request_id: request.request_id,
+            provider_id: self.provider_id.clone(),
+            provider_name: self.provider_name.clone(),
+            model: parsed.model.unwrap_or(settings.model),
+            content,
+            latency_ms,
+            finish_reason,
+            usage: parsed.usage.map(|usage| ProviderUsage {
+                prompt_tokens: usage.prompt_tokens,
+                completion_tokens: usage.completion_tokens,
+                total_tokens: usage.total_tokens,
+            }),
+        })
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct OpenAiChatCompletionRequest {
+    model: String,
+    messages: Vec<ChatMessage>,
+    temperature: f64,
+    top_p: f64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    max_tokens: Option<u32>,
+}
+
+#[derive(Debug, Deserialize)]
+struct OpenAiChatCompletionResponse {
+    model: Option<String>,
+    choices: Vec<OpenAiChoice>,
+    usage: Option<OpenAiUsage>,
+}
+
+#[derive(Debug, Deserialize)]
+struct OpenAiChoice {
+    message: OpenAiMessage,
+    finish_reason: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct OpenAiMessage {
+    content: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct OpenAiUsage {
+    prompt_tokens: Option<u32>,
+    completion_tokens: Option<u32>,
+    total_tokens: Option<u32>,
+}
+
+#[derive(Debug, Clone)]
+struct ResolvedRequestSettings {
+    model: String,
+    temperature: f64,
+    top_p: f64,
+    max_tokens: Option<u32>,
+    timeout_secs: u64,
+}
+
+fn provider_error(
+    provider_id: &str,
+    code: ProviderErrorCode,
+    message: impl Into<String>,
+) -> ProviderError {
+    ProviderError::new(provider_id.to_string(), code, message)
+}
+
+fn normalized_provider_id(provider_id: &str) -> Result<String, ProviderError> {
+    let trimmed = provider_id.trim();
+    if trimmed.is_empty() {
+        return Err(provider_error(
+            provider_id,
+            ProviderErrorCode::InvalidProviderId,
+            "provider id must not be empty",
+        ));
+    }
+
+    Ok(trimmed.to_string())
+}
+
+fn normalized_name(name: &str, fallback: &str) -> String {
+    let trimmed = name.trim();
+    if trimmed.is_empty() {
+        fallback.to_string()
+    } else {
+        trimmed.to_string()
+    }
+}
+
+fn normalized_optional_string(value: &str) -> Option<String> {
+    non_empty_string(value).map(ToOwned::to_owned)
+}
+
+fn normalized_optional_string_option(value: Option<String>) -> Option<String> {
+    value.and_then(|value| non_empty_string(&value).map(ToOwned::to_owned))
+}
+
+fn non_empty_string(value: &str) -> Option<&str> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed)
+    }
+}
+
+fn build_endpoint(provider_id: &str, base_url: &str, path: &str) -> Result<Url, ProviderError> {
+    let normalized_base = base_url.trim();
+    if normalized_base.is_empty() {
+        return Err(provider_error(
+            provider_id,
+            ProviderErrorCode::InvalidBaseUrl,
+            "base URL is required",
+        ));
+    }
+
+    let parsed_base = Url::parse(normalized_base).map_err(|error| {
+        provider_error(
+            provider_id,
+            ProviderErrorCode::InvalidBaseUrl,
+            "base URL is invalid",
+        )
+        .with_details(error.to_string())
+    })?;
+
+    let scheme = parsed_base.scheme();
+    let host = parsed_base.host_str().unwrap_or_default();
+    let is_local_http = scheme == "http" && is_loopback_host(host);
+    if scheme != "https" && !is_local_http {
+        return Err(provider_error(
+            provider_id,
+            ProviderErrorCode::InvalidBaseUrl,
+            "base URL must use https, or http only for localhost/loopback development endpoints",
+        ));
+    }
+
+    let normalized_path = if path.trim().is_empty() {
+        DEFAULT_CHAT_COMPLETIONS_PATH
+    } else {
+        path.trim()
+    };
+    let endpoint = parsed_base
+        .join(normalized_path.trim_start_matches('/'))
+        .map_err(|error| {
+            provider_error(
+                provider_id,
+                ProviderErrorCode::InvalidEndpointPath,
+                "endpoint path is invalid",
+            )
+            .with_details(error.to_string())
+        })?;
+
+    Ok(endpoint)
+}
+
+fn is_loopback_host(host: &str) -> bool {
+    if host.eq_ignore_ascii_case("localhost") {
+        return true;
+    }
+
+    host.parse::<std::net::IpAddr>()
+        .map(|ip_addr| ip_addr.is_loopback())
+        .unwrap_or(false)
+}
+
+fn build_custom_headers(
+    provider_id: &str,
+    headers: &[KeyValuePairRecord],
+) -> Result<HeaderMap, ProviderError> {
+    let mut header_map = HeaderMap::new();
+    let mut seen_names = HashSet::new();
+
+    for header in headers {
+        let name = header.name.trim();
+        let value = header.value.trim();
+
+        if name.is_empty() {
+            return Err(provider_error(
+                provider_id,
+                ProviderErrorCode::InvalidHeaderName,
+                "custom header name is required",
+            ));
+        }
+
+        if value.is_empty() {
+            return Err(provider_error(
+                provider_id,
+                ProviderErrorCode::InvalidHeaderValue,
+                format!("custom header '{name}' has an empty value"),
+            ));
+        }
+
+        let lower_name = name.to_ascii_lowercase();
+        if !seen_names.insert(lower_name.clone()) {
+            return Err(provider_error(
+                provider_id,
+                ProviderErrorCode::InvalidHeaderOverride,
+                format!("custom header '{name}' is duplicated"),
+            ));
+        }
+
+        if is_blocked_header_name(&lower_name) {
+            return Err(provider_error(
+                provider_id,
+                ProviderErrorCode::InvalidHeaderOverride,
+                format!("custom header '{name}' is not allowed"),
+            ));
+        }
+
+        if value.contains('\r') || value.contains('\n') {
+            return Err(provider_error(
+                provider_id,
+                ProviderErrorCode::InvalidHeaderValue,
+                format!("custom header '{name}' contains line breaks"),
+            ));
+        }
+
+        let header_name = HeaderName::from_bytes(name.as_bytes()).map_err(|error| {
+            provider_error(
+                provider_id,
+                ProviderErrorCode::InvalidHeaderName,
+                format!("custom header '{name}' is invalid"),
+            )
+            .with_details(error.to_string())
+        })?;
+        let header_value = HeaderValue::from_str(value).map_err(|error| {
+            provider_error(
+                provider_id,
+                ProviderErrorCode::InvalidHeaderValue,
+                format!("custom header '{name}' has an invalid value"),
+            )
+            .with_details(error.to_string())
+        })?;
+
+        header_map.insert(header_name, header_value);
+    }
+
+    Ok(header_map)
+}
+
+fn is_blocked_header_name(name: &str) -> bool {
+    matches!(
+        name,
+        "authorization"
+            | "connection"
+            | "content-length"
+            | "content-type"
+            | "host"
+            | "proxy-authorization"
+            | "transfer-encoding"
+            | "upgrade"
+    )
+}
+
+fn validate_temperature(provider_id: &str, value: f64) -> Result<f64, ProviderError> {
+    if !value.is_finite() || !(MIN_TEMPERATURE..=MAX_TEMPERATURE).contains(&value) {
+        return Err(provider_error(
+            provider_id,
+            ProviderErrorCode::InvalidTemperature,
+            "temperature must be between 0 and 2",
+        ));
+    }
+
+    Ok(value)
+}
+
+fn validate_top_p(provider_id: &str, value: f64) -> Result<f64, ProviderError> {
+    if !value.is_finite() || !(MIN_TOP_P..=MAX_TOP_P).contains(&value) {
+        return Err(provider_error(
+            provider_id,
+            ProviderErrorCode::InvalidTopP,
+            "top_p must be between 0 and 1",
+        ));
+    }
+
+    Ok(value)
+}
+
+fn validate_max_tokens(provider_id: &str, value: u32) -> Result<u32, ProviderError> {
+    if value == 0 {
+        return Err(provider_error(
+            provider_id,
+            ProviderErrorCode::InvalidMaxTokens,
+            "max_tokens must be greater than zero",
+        ));
+    }
+
+    Ok(value)
+}
+
+fn validate_timeout_secs(provider_id: &str, value: u64) -> Result<u64, ProviderError> {
+    if !(MIN_TIMEOUT_SECS..=MAX_TIMEOUT_SECS).contains(&value) {
+        return Err(provider_error(
+            provider_id,
+            ProviderErrorCode::InvalidTimeout,
+            "timeout must be between 3 and 120 seconds",
+        ));
+    }
+
+    Ok(value)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::{
+        io::{Read, Write},
+        net::TcpListener,
+        sync::{Arc, Mutex},
+        thread,
+    };
+
+    use crate::{
+        models::config::{AuthScheme, ProviderConfigRecord},
+        services::provider::ChatRole,
+    };
+
+    fn provider_config(base_url: String) -> ProviderConfigRecord {
+        ProviderConfigRecord {
+            id: "provider-1".to_string(),
+            name: "OpenAI-compatible".to_string(),
+            kind: crate::models::config::ProviderKind::OpenAiCompatible,
+            base_url,
+            path: DEFAULT_CHAT_COMPLETIONS_PATH.to_string(),
+            auth_scheme: AuthScheme::Bearer,
+            api_key_ref: Some("provider/provider-1".to_string()),
+            organization: Some("org-123".to_string()),
+            model: "gpt-4o-mini".to_string(),
+            temperature: 0.3,
+            top_p: 0.95,
+            max_tokens: Some(256),
+            timeout_secs: 5,
+            custom_headers: vec![KeyValuePairRecord {
+                name: "X-Test".to_string(),
+                value: "value".to_string(),
+            }],
+            enabled: true,
+        }
+    }
+
+    fn start_test_server(
+        response_body: &'static str,
+    ) -> (String, Arc<Mutex<Option<String>>>, thread::JoinHandle<()>) {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind test server");
+        let addr = listener.local_addr().expect("local addr");
+        let captured_request = Arc::new(Mutex::new(None));
+        let captured_request_clone = Arc::clone(&captured_request);
+
+        let handle = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().expect("accept request");
+            let mut request = Vec::new();
+            let mut buffer = [0u8; 1024];
+
+            loop {
+                let read = stream.read(&mut buffer).expect("read request");
+                if read == 0 {
+                    break;
+                }
+                request.extend_from_slice(&buffer[..read]);
+                if request.windows(4).any(|window| window == b"\r\n\r\n") {
+                    break;
+                }
+            }
+
+            let header_end = request
+                .windows(4)
+                .position(|window| window == b"\r\n\r\n")
+                .expect("headers end");
+            let headers = String::from_utf8(request[..header_end].to_vec()).expect("utf8 headers");
+            let content_length = headers
+                .lines()
+                .find_map(|line| {
+                    let (name, value) = line.split_once(':')?;
+                    if name.trim().eq_ignore_ascii_case("content-length") {
+                        Some(value.trim().parse::<usize>().ok())
+                    } else {
+                        None
+                    }
+                })
+                .flatten()
+                .expect("content length");
+            let mut body = request[header_end + 4..].to_vec();
+
+            while body.len() < content_length {
+                let read = stream.read(&mut buffer).expect("read body");
+                if read == 0 {
+                    break;
+                }
+                body.extend_from_slice(&buffer[..read]);
+            }
+
+            let full_request = format!(
+                "{}\r\n\r\n{}",
+                headers,
+                String::from_utf8(body.clone()).expect("utf8 body")
+            );
+            *captured_request_clone.lock().expect("lock request") = Some(full_request);
+
+            let response = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                response_body.len(),
+                response_body
+            );
+            stream
+                .write_all(response.as_bytes())
+                .expect("write response");
+        });
+
+        (format!("http://{}", addr), captured_request, handle)
+    }
+
+    #[test]
+    fn try_from_config_rejects_invalid_base_url() {
+        let mut config = provider_config("ftp://example.com".to_string());
+        config.custom_headers.clear();
+
+        let error = OpenAiCompatibleProvider::try_from_config(config, Some("sk-test".to_string()))
+            .expect_err("invalid base url");
+
+        assert_eq!(error.code, ProviderErrorCode::InvalidBaseUrl);
+    }
+
+    #[test]
+    fn try_from_config_rejects_header_injection_and_blocked_headers() {
+        let mut config = provider_config("https://example.com".to_string());
+        config.custom_headers = vec![KeyValuePairRecord {
+            name: "Host".to_string(),
+            value: "evil.example.com".to_string(),
+        }];
+
+        let error = OpenAiCompatibleProvider::try_from_config(config, Some("sk-test".to_string()))
+            .expect_err("blocked host header");
+
+        assert_eq!(error.code, ProviderErrorCode::InvalidHeaderOverride);
+
+        let mut config = provider_config("https://example.com".to_string());
+        config.custom_headers = vec![KeyValuePairRecord {
+            name: "X-Test".to_string(),
+            value: "bad\nvalue".to_string(),
+        }];
+
+        let error = OpenAiCompatibleProvider::try_from_config(config, Some("sk-test".to_string()))
+            .expect_err("header newline injection");
+
+        assert_eq!(error.code, ProviderErrorCode::InvalidHeaderValue);
+    }
+
+    #[tokio::test]
+    async fn translate_sends_expected_payload_and_parses_response() {
+        let (base_url, captured_request, server_handle) = start_test_server(
+            r#"{
+                "model": "gpt-4o-mini",
+                "choices": [
+                    {
+                        "message": { "content": "translated output" },
+                        "finish_reason": "stop"
+                    }
+                ],
+                "usage": {
+                    "prompt_tokens": 10,
+                    "completion_tokens": 5,
+                    "total_tokens": 15
+                }
+            }"#,
+        );
+
+        let provider = OpenAiCompatibleProvider::try_from_config(
+            provider_config(base_url),
+            Some("sk-test".to_string()),
+        )
+        .expect("provider");
+
+        let response = provider
+            .translate(ProviderRequest {
+                request_id: Some("req-1".to_string()),
+                model: None,
+                messages: vec![
+                    ChatMessage {
+                        role: ChatRole::System,
+                        content: "You are a translator.".to_string(),
+                    },
+                    ChatMessage {
+                        role: ChatRole::User,
+                        content: "Hello".to_string(),
+                    },
+                ],
+                temperature: Some(0.4),
+                top_p: Some(0.9),
+                max_tokens: Some(128),
+                timeout_secs: Some(5),
+            })
+            .await
+            .expect("response");
+
+        server_handle.join().expect("server thread");
+
+        assert_eq!(response.request_id.as_deref(), Some("req-1"));
+        assert_eq!(response.provider_id, "provider-1");
+        assert_eq!(response.provider_name, "OpenAI-compatible");
+        assert_eq!(response.model, "gpt-4o-mini");
+        assert_eq!(response.content, "translated output");
+        assert_eq!(response.finish_reason.as_deref(), Some("stop"));
+        assert_eq!(
+            response.usage,
+            Some(ProviderUsage {
+                prompt_tokens: Some(10),
+                completion_tokens: Some(5),
+                total_tokens: Some(15),
+            })
+        );
+
+        let captured = captured_request
+            .lock()
+            .expect("request")
+            .clone()
+            .expect("captured");
+        let captured_lower = captured.to_ascii_lowercase();
+        assert!(captured_lower.contains("post /chat/completions http/1.1"));
+        assert!(captured_lower.contains("authorization: bearer sk-test"));
+        assert!(captured_lower.contains("openai-organization: org-123"));
+        assert!(captured_lower.contains("x-test: value"));
+        assert!(captured_lower.contains("\"model\":\"gpt-4o-mini\""));
+        assert!(captured_lower.contains("\"temperature\":0.4"));
+        assert!(captured_lower.contains("\"top_p\":0.9"));
+        assert!(captured_lower.contains("\"max_tokens\":128"));
+        assert!(captured_lower.contains("\"role\":\"system\""));
+        assert!(captured_lower.contains("\"role\":\"user\""));
+    }
+
+    #[tokio::test]
+    async fn translate_rejects_missing_api_key_for_bearer_auth() {
+        let mut config = provider_config("https://example.com".to_string());
+        config.custom_headers.clear();
+
+        let provider = OpenAiCompatibleProvider::try_from_config(config, None).expect("provider");
+        let error = provider
+            .translate(ProviderRequest {
+                messages: vec![ChatMessage {
+                    role: ChatRole::User,
+                    content: "Hello".to_string(),
+                }],
+                ..ProviderRequest::default()
+            })
+            .await
+            .expect_err("missing api key");
+
+        assert_eq!(error.code, ProviderErrorCode::MissingApiKey);
+    }
+
+    #[tokio::test]
+    async fn translate_surfaces_http_status_errors() {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind test server");
+        let addr = listener.local_addr().expect("local addr");
+
+        let handle = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().expect("accept request");
+            let mut request = [0u8; 1024];
+            let _ = stream.read(&mut request).expect("read request");
+            let body = "{\"error\":\"unauthorized\"}";
+            let response = format!(
+                "HTTP/1.1 401 Unauthorized\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                body.len(),
+                body
+            );
+            stream
+                .write_all(response.as_bytes())
+                .expect("write response");
+        });
+
+        let provider = OpenAiCompatibleProvider::try_from_config(
+            provider_config(format!("http://{addr}")),
+            Some("sk-test".to_string()),
+        )
+        .expect("provider");
+
+        let error = provider
+            .translate(ProviderRequest {
+                messages: vec![ChatMessage {
+                    role: ChatRole::User,
+                    content: "Hello".to_string(),
+                }],
+                ..ProviderRequest::default()
+            })
+            .await
+            .expect_err("http status error");
+
+        handle.join().expect("server thread");
+
+        assert_eq!(error.code, ProviderErrorCode::HttpStatus);
+        assert_eq!(error.status, Some(401));
+        assert!(error
+            .details
+            .as_deref()
+            .unwrap_or_default()
+            .contains("unauthorized"));
+    }
+}


### PR DESCRIPTION
Implements Task 07 provider abstraction only.

What changed:
- Unified provider request/response/error types under Rust backend
- Added TranslationProvider trait
- Added OpenAI-compatible provider with configurable base URL, path, headers, auth scheme, model, timeout, temperature, top_p, and max_tokens
- Added URL and header injection validation
- Added displayable error structures
- Added provider-focused unit tests

Validation:
- cargo check --manifest-path apps/desktop/src-tauri/Cargo.toml
- cargo test --manifest-path apps/desktop/src-tauri/Cargo.toml provider -- --nocapture
- rustfmt --edition 2021 --check apps/desktop/src-tauri/src/services/provider/mod.rs apps/desktop/src-tauri/src/services/provider/openai_compatible.rs

Scope note:
- No language routing or translation orchestration wiring yet