### PR TITLE
[codex] Add trigger manager

### DIFF
--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -277,6 +277,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "block"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -505,16 +511,33 @@ dependencies = [
  "async-trait",
  "directories",
  "keyring",
+ "rdev",
  "reqwest 0.12.28",
  "serde",
  "serde_json",
  "tauri",
  "tauri-build",
  "tauri-plugin-clipboard-manager",
+ "tauri-plugin-global-shortcut",
  "tauri-plugin-opener",
  "tokio",
  "toml 0.8.2",
  "url",
+]
+
+[[package]]
+name = "cocoa"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "667fdc068627a2816b9ff831201dd9864249d6ee8d190b9532357f1fc0f61ea7"
+dependencies = [
+ "bitflags 1.3.2",
+ "block",
+ "core-foundation 0.9.4",
+ "core-graphics 0.21.0",
+ "foreign-types 0.3.2",
+ "libc",
+ "objc",
 ]
 
 [[package]]
@@ -554,11 +577,21 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57d24c7a13c43e870e37c1556b74555437870a04514f7685f5b354e090567171"
+dependencies = [
+ "core-foundation-sys 0.7.0",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
 dependencies = [
- "core-foundation-sys",
+ "core-foundation-sys 0.8.7",
  "libc",
 ]
 
@@ -568,15 +601,45 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
 dependencies = [
- "core-foundation-sys",
+ "core-foundation-sys 0.8.7",
  "libc",
 ]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3a71ab494c0b5b860bdc8407ae08978052417070c2ced38573a9157ad75b8ac"
 
 [[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "core-graphics"
+version = "0.19.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3889374e6ea6ab25dba90bb5d96202f61108058361f6dc72e8b03e6f8bbe923"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation 0.7.0",
+ "foreign-types 0.3.2",
+ "libc",
+]
+
+[[package]]
+name = "core-graphics"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52a67c4378cf203eace8fb6567847eb641fd6ff933c1145a115c6ee820ebb978"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation 0.9.4",
+ "foreign-types 0.3.2",
+ "libc",
+]
 
 [[package]]
 name = "core-graphics"
@@ -587,7 +650,7 @@ dependencies = [
  "bitflags 2.11.0",
  "core-foundation 0.10.1",
  "core-graphics-types",
- "foreign-types",
+ "foreign-types 0.5.0",
  "libc",
 ]
 
@@ -1131,12 +1194,21 @@ checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared 0.1.1",
+]
+
+[[package]]
+name = "foreign-types"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
 dependencies = [
  "foreign-types-macros",
- "foreign-types-shared",
+ "foreign-types-shared 0.3.1",
 ]
 
 [[package]]
@@ -1149,6 +1221,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "foreign-types-shared"
@@ -1524,6 +1602,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
+name = "global-hotkey"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9247516746aa8e53411a0db9b62b0e24efbcf6a76e0ba73e5a91b512ddabed7"
+dependencies = [
+ "crossbeam-channel",
+ "keyboard-types",
+ "objc2",
+ "objc2-app-kit",
+ "once_cell",
+ "serde",
+ "thiserror 2.0.18",
+ "windows-sys 0.59.0",
+ "x11rb",
+ "xkeysym",
+]
+
+[[package]]
 name = "gobject-sys"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1770,7 +1866,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
 dependencies = [
  "android_system_properties",
- "core-foundation-sys",
+ "core-foundation-sys 0.8.7",
  "iana-time-zone-haiku",
  "js-sys",
  "log",
@@ -2139,6 +2235,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2240,6 +2342,15 @@ name = "mac"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
+
+[[package]]
+name = "malloc_buf"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "markup5ever"
@@ -2442,6 +2553,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "objc"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1"
+dependencies = [
+ "malloc_buf",
 ]
 
 [[package]]
@@ -3283,6 +3403,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
 
 [[package]]
+name = "rdev"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00552ca2dc2f93b84cd7b5581de49549411e4e41d89e1c691bcb93dc4be360c3"
+dependencies = [
+ "cocoa",
+ "core-foundation 0.7.0",
+ "core-foundation-sys 0.7.0",
+ "core-graphics 0.19.2",
+ "lazy_static",
+ "libc",
+ "winapi",
+ "x11",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3586,7 +3722,7 @@ checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
  "bitflags 2.11.0",
  "core-foundation 0.9.4",
- "core-foundation-sys",
+ "core-foundation-sys 0.8.7",
  "libc",
  "security-framework-sys",
 ]
@@ -3599,7 +3735,7 @@ checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
  "bitflags 2.11.0",
  "core-foundation 0.10.1",
- "core-foundation-sys",
+ "core-foundation-sys 0.8.7",
  "libc",
  "security-framework-sys",
 ]
@@ -3610,7 +3746,7 @@ version = "2.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
 dependencies = [
- "core-foundation-sys",
+ "core-foundation-sys 0.8.7",
  "libc",
 ]
 
@@ -4097,7 +4233,7 @@ dependencies = [
  "bitflags 2.11.0",
  "block2",
  "core-foundation 0.10.1",
- "core-graphics",
+ "core-graphics 0.25.0",
  "crossbeam-channel",
  "dispatch2",
  "dlopen2",
@@ -4282,6 +4418,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "206dc20af4ed210748ba945c2774e60fd0acd52b9a73a028402caf809e9b6ecf"
 dependencies = [
  "arboard",
+ "log",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "tauri-plugin-global-shortcut"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "424af23c7e88d05e4a1a6fc2c7be077912f8c76bd7900fd50aa2b7cbf5a2c405"
+dependencies = [
+ "global-hotkey",
  "log",
  "serde",
  "serde_json",
@@ -6006,6 +6157,12 @@ name = "x11rb-protocol"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
+
+[[package]]
+name = "xkeysym"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
 
 [[package]]
 name = "yoke"

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -20,9 +20,11 @@ tauri-build = { version = "2", features = [] }
 [dependencies]
 async-trait = "0.1"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+rdev = "0.5"
 tauri = { version = "2", features = ["tray-icon", "image-png"] }
 tauri-plugin-opener = "2"
 tauri-plugin-clipboard-manager = "2"
+tauri-plugin-global-shortcut = "2"
 directories = "6"
 keyring = { version = "3", features = ["apple-native", "windows-native", "sync-secret-service"] }
 serde = { version = "1", features = ["derive"] }

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -6,6 +6,10 @@ use models::config::{AppConfigRecord, ProviderConfigRecord};
 use services::{
     clipboard::{read_clipboard_text, read_clipboard_text_with_limits, ClipboardLimits},
     config::{ConfigService, ProviderSecretStatus},
+    trigger::{
+        dispatch_translation_trigger, initialize_trigger_services, TriggerDispatchPayload,
+        TriggerSource,
+    },
 };
 use storage::{fs_paths::ProjectPathProvider, secure_storage::KeyringSecretStore};
 use tauri::{
@@ -229,6 +233,14 @@ async fn delete_provider_api_key(provider_id: String) -> Result<ProviderSecretSt
         .map_err(|error| error.to_string())
 }
 
+#[tauri::command]
+async fn trigger_translation_from_fallback_shortcut(
+    app: AppHandle,
+) -> Result<TriggerDispatchPayload, String> {
+    dispatch_translation_trigger(&app, TriggerSource::FallbackShortcut)
+        .map_err(|error| error.to_string())
+}
+
 fn build_tray(app: &AppHandle) -> tauri::Result<()> {
     let show_main = MenuItem::with_id(
         app,
@@ -273,6 +285,7 @@ pub fn run() {
         .plugin(tauri_plugin_clipboard_manager::init())
         .setup(|app| {
             let handle = app.handle().clone();
+            let config = config_service().load()?;
             let main_window = if let Some(window) = handle.get_webview_window(MAIN_WINDOW_LABEL) {
                 window
             } else {
@@ -281,6 +294,11 @@ pub fn run() {
             bind_hide_on_close(&main_window);
 
             build_tray(&handle)?;
+            initialize_trigger_services(
+                &handle,
+                &config.trigger.fallback_shortcut,
+                config.trigger.double_copy_window_ms,
+            );
             Ok(())
         })
         .invoke_handler(tauri::generate_handler![
@@ -297,7 +315,8 @@ pub fn run() {
             set_active_provider,
             set_provider_api_key,
             get_provider_api_key_status,
-            delete_provider_api_key
+            delete_provider_api_key,
+            trigger_translation_from_fallback_shortcut
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/apps/desktop/src-tauri/src/services/mod.rs
+++ b/apps/desktop/src-tauri/src/services/mod.rs
@@ -1,3 +1,4 @@
 pub mod clipboard;
 pub mod config;
 pub mod provider;
+pub mod trigger;

--- a/apps/desktop/src-tauri/src/services/trigger.rs
+++ b/apps/desktop/src-tauri/src/services/trigger.rs
@@ -1,0 +1,303 @@
+use std::{
+    sync::{Arc, Mutex},
+    thread,
+    time::{Duration, Instant},
+};
+
+use rdev::{listen, Event, EventType, Key};
+use serde::Serialize;
+use tauri::{AppHandle, Emitter, Manager, WebviewUrl, WebviewWindowBuilder};
+use tauri_plugin_global_shortcut::{
+    Builder as GlobalShortcutBuilder, Code, Modifiers, Shortcut, ShortcutState,
+};
+
+use crate::{
+    services::clipboard::{read_clipboard_text, ClipboardServiceError, ClipboardText},
+    MAIN_WINDOW_LABEL, POPUP_WINDOW_LABEL,
+};
+
+pub const TRANSLATION_TRIGGER_EVENT: &str = "trigger:translation-requested";
+pub const DEFAULT_FALLBACK_SHORTCUT: &str = "CmdOrCtrl+Shift+Y";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum TriggerSource {
+    DoubleCopy,
+    FallbackShortcut,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TriggerDispatchPayload {
+    pub source: TriggerSource,
+    pub text: String,
+    pub character_count: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TriggerServiceError {
+    Clipboard(ClipboardServiceError),
+    ShortcutRegistration(String),
+}
+
+impl std::fmt::Display for TriggerServiceError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Clipboard(error) => write!(f, "{error}"),
+            Self::ShortcutRegistration(error) => {
+                write!(f, "failed to register fallback shortcut: {error}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for TriggerServiceError {}
+
+#[derive(Debug)]
+pub struct CopyTriggerStateMachine {
+    window: Duration,
+    last_copy_at: Option<Instant>,
+}
+
+impl CopyTriggerStateMachine {
+    pub fn new(window: Duration) -> Self {
+        Self {
+            window,
+            last_copy_at: None,
+        }
+    }
+
+    pub fn register_copy(&mut self, now: Instant) -> bool {
+        if let Some(previous) = self.last_copy_at {
+            if now.duration_since(previous) <= self.window {
+                self.last_copy_at = None;
+                return true;
+            }
+        }
+
+        self.last_copy_at = Some(now);
+        false
+    }
+}
+
+#[derive(Debug, Default, Clone, Copy)]
+struct ModifierState {
+    control_pressed: bool,
+    meta_pressed: bool,
+}
+
+impl ModifierState {
+    fn apply_key_press(&mut self, key: Key) {
+        match key {
+            Key::ControlLeft | Key::ControlRight => self.control_pressed = true,
+            Key::MetaLeft | Key::MetaRight => self.meta_pressed = true,
+            _ => {}
+        }
+    }
+
+    fn apply_key_release(&mut self, key: Key) {
+        match key {
+            Key::ControlLeft | Key::ControlRight => self.control_pressed = false,
+            Key::MetaLeft | Key::MetaRight => self.meta_pressed = false,
+            _ => {}
+        }
+    }
+
+    fn copy_modifier_active(self) -> bool {
+        self.control_pressed || self.meta_pressed
+    }
+}
+
+pub fn initialize_trigger_services(app: &AppHandle, shortcut: &str, double_copy_window_ms: u64) {
+    if let Err(error) = register_fallback_shortcut(app, shortcut) {
+        eprintln!("{error}");
+        if shortcut != DEFAULT_FALLBACK_SHORTCUT {
+            let _ = register_fallback_shortcut(app, DEFAULT_FALLBACK_SHORTCUT)
+                .map_err(|fallback_error| eprintln!("{fallback_error}"));
+        }
+    }
+
+    spawn_double_copy_listener(app.clone(), double_copy_window_ms);
+}
+
+pub fn dispatch_translation_trigger(
+    app: &AppHandle,
+    source: TriggerSource,
+) -> Result<TriggerDispatchPayload, TriggerServiceError> {
+    let clipboard = read_clipboard_text(app.clone()).map_err(TriggerServiceError::Clipboard)?;
+    let payload = build_payload(source, clipboard);
+
+    let popup_window = if let Some(window) = app.get_webview_window(POPUP_WINDOW_LABEL) {
+        window
+    } else {
+        WebviewWindowBuilder::new(
+            app,
+            POPUP_WINDOW_LABEL,
+            WebviewUrl::App("index.html".into()),
+        )
+        .title("ClipLingo Translation")
+        .inner_size(560.0, 380.0)
+        .min_inner_size(420.0, 280.0)
+        .decorations(false)
+        .always_on_top(true)
+        .skip_taskbar(true)
+        .visible(false)
+        .build()
+        .map_err(|error| TriggerServiceError::ShortcutRegistration(error.to_string()))?
+    };
+    let _ = popup_window.show();
+    let _ = popup_window.set_focus();
+
+    app.emit(TRANSLATION_TRIGGER_EVENT, &payload)
+        .map_err(|error| TriggerServiceError::ShortcutRegistration(error.to_string()))?;
+
+    if let Some(main_window) = app.get_webview_window(MAIN_WINDOW_LABEL) {
+        let _ = main_window.emit(TRANSLATION_TRIGGER_EVENT, &payload);
+    }
+
+    Ok(payload)
+}
+
+fn build_payload(source: TriggerSource, clipboard: ClipboardText) -> TriggerDispatchPayload {
+    TriggerDispatchPayload {
+        source,
+        text: clipboard.text,
+        character_count: clipboard.character_count,
+    }
+}
+
+fn register_fallback_shortcut(app: &AppHandle, shortcut: &str) -> Result<(), TriggerServiceError> {
+    let fallback_shortcut = parse_shortcut(shortcut).unwrap_or_else(default_shortcut);
+    let app_handle = app.clone();
+
+    app.plugin(
+        GlobalShortcutBuilder::new()
+            .with_shortcuts([fallback_shortcut])
+            .map_err(|error| TriggerServiceError::ShortcutRegistration(error.to_string()))?
+            .with_handler(move |_app, triggered_shortcut, event| {
+                if event.state() == ShortcutState::Pressed
+                    && triggered_shortcut == &fallback_shortcut
+                {
+                    let _ =
+                        dispatch_translation_trigger(&app_handle, TriggerSource::FallbackShortcut);
+                }
+            })
+            .build(),
+    )
+    .map_err(|error: tauri::Error| TriggerServiceError::ShortcutRegistration(error.to_string()))
+}
+
+fn spawn_double_copy_listener(app: AppHandle, double_copy_window_ms: u64) {
+    let state_machine = Arc::new(Mutex::new(CopyTriggerStateMachine::new(
+        Duration::from_millis(normalized_window_ms(double_copy_window_ms)),
+    )));
+    let modifiers = Arc::new(Mutex::new(ModifierState::default()));
+
+    thread::spawn(move || {
+        let state_machine = Arc::clone(&state_machine);
+        let modifiers = Arc::clone(&modifiers);
+
+        if let Err(error) = listen(move |event| {
+            handle_global_event(&app, &state_machine, &modifiers, event);
+        }) {
+            eprintln!("double-copy listener unavailable: {error:?}");
+        }
+    });
+}
+
+fn handle_global_event(
+    app: &AppHandle,
+    state_machine: &Arc<Mutex<CopyTriggerStateMachine>>,
+    modifiers: &Arc<Mutex<ModifierState>>,
+    event: Event,
+) {
+    match event.event_type {
+        EventType::KeyPress(key) => {
+            let mut modifier_state = modifiers.lock().expect("modifier state lock");
+            modifier_state.apply_key_press(key);
+
+            if key == Key::KeyC && modifier_state.copy_modifier_active() {
+                let mut trigger_state = state_machine.lock().expect("trigger state lock");
+                if trigger_state.register_copy(Instant::now()) {
+                    let _ = dispatch_translation_trigger(app, TriggerSource::DoubleCopy);
+                }
+            }
+        }
+        EventType::KeyRelease(key) => {
+            modifiers
+                .lock()
+                .expect("modifier state lock")
+                .apply_key_release(key);
+        }
+        _ => {}
+    }
+}
+
+fn normalized_window_ms(value: u64) -> u64 {
+    value.clamp(250, 800)
+}
+
+fn parse_shortcut(input: &str) -> Option<Shortcut> {
+    let trimmed = input.trim();
+    if trimmed.eq_ignore_ascii_case("CmdOrCtrl+Shift+Y") {
+        return Some(default_shortcut());
+    }
+
+    None
+}
+
+fn default_shortcut() -> Shortcut {
+    #[cfg(target_os = "macos")]
+    let modifiers = Modifiers::META | Modifiers::SHIFT;
+    #[cfg(not(target_os = "macos"))]
+    let modifiers = Modifiers::CONTROL | Modifiers::SHIFT;
+
+    Shortcut::new(Some(modifiers), Code::KeyY)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn state_machine_only_triggers_for_second_copy_within_window() {
+        let start = Instant::now();
+        let mut machine = CopyTriggerStateMachine::new(Duration::from_millis(450));
+
+        assert!(!machine.register_copy(start));
+        assert!(machine.register_copy(start + Duration::from_millis(300)));
+        assert!(!machine.register_copy(start + Duration::from_millis(700)));
+        assert!(!machine.register_copy(start + Duration::from_millis(1_200)));
+    }
+
+    #[test]
+    fn state_machine_resets_when_second_copy_is_too_late() {
+        let start = Instant::now();
+        let mut machine = CopyTriggerStateMachine::new(Duration::from_millis(450));
+
+        assert!(!machine.register_copy(start));
+        assert!(!machine.register_copy(start + Duration::from_millis(500)));
+        assert!(machine.register_copy(start + Duration::from_millis(850)));
+    }
+
+    #[test]
+    fn modifier_state_tracks_copy_modifiers() {
+        let mut modifiers = ModifierState::default();
+
+        modifiers.apply_key_press(Key::ControlLeft);
+        assert!(modifiers.copy_modifier_active());
+
+        modifiers.apply_key_release(Key::ControlLeft);
+        assert!(!modifiers.copy_modifier_active());
+
+        modifiers.apply_key_press(Key::MetaLeft);
+        assert!(modifiers.copy_modifier_active());
+    }
+
+    #[test]
+    fn normalizes_window_bounds() {
+        assert_eq!(normalized_window_ms(100), 250);
+        assert_eq!(normalized_window_ms(450), 450);
+        assert_eq!(normalized_window_ms(900), 800);
+    }
+}


### PR DESCRIPTION
## Summary
- add a double-copy trigger state machine and global keyboard listener for Cmd/Ctrl+C+C
- register a fallback global shortcut and route both trigger paths through the same clipboard-driven popup dispatch
- add focused tests for timing window behavior and modifier tracking

## Validation
- `cargo fmt --manifest-path src-tauri/Cargo.toml`
- `cargo test --manifest-path src-tauri/Cargo.toml trigger`
- `cargo check --manifest-path src-tauri/Cargo.toml`

## Risks
- Global double-copy detection depends on `rdev`, which requires Accessibility permission on macOS and may vary across apps.

Refs #6
