### PR TITLE
[codex] Task 13: harden security validators

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -277,11 +277,6 @@ async fn translate_text(input: TranslateTextInput) -> Result<TranslationExecutio
         .execute(resolved_provider, config, input.clone())
         .await
     {
-<<<<<<< HEAD
-        Ok(output) => Ok(output),
-        Err(error) => Ok(TranslationExecutionOutput::from_safe_error(&input, &error)),
-    }
-=======
         Ok(output) => {
             let config = config_service().load().map_err(|error| error.to_string())?;
             let _ = history_repository().append_translation(&config.history, &output);
@@ -332,7 +327,6 @@ async fn clear_translation_history() -> Result<(), String> {
     history_repository()
         .clear()
         .map_err(|error| error.to_string())
->>>>>>> origin/develop
 }
 
 #[tauri::command]

--- a/apps/desktop/src-tauri/src/services/provider/openai_compatible.rs
+++ b/apps/desktop/src-tauri/src/services/provider/openai_compatible.rs
@@ -391,6 +391,22 @@ fn build_endpoint(provider_id: &str, base_url: &str, path: &str) -> Result<Url, 
         ));
     }
 
+    if !parsed_base.username().is_empty() || parsed_base.password().is_some() {
+        return Err(provider_error(
+            provider_id,
+            ProviderErrorCode::InvalidBaseUrl,
+            "base URL must not include embedded credentials",
+        ));
+    }
+
+    if parsed_base.query().is_some() || parsed_base.fragment().is_some() {
+        return Err(provider_error(
+            provider_id,
+            ProviderErrorCode::InvalidBaseUrl,
+            "base URL must not include query strings or fragments",
+        ));
+    }
+
     let normalized_path = if path.trim().is_empty() {
         DEFAULT_CHAT_COMPLETIONS_PATH
     } else {
@@ -674,6 +690,38 @@ mod tests {
         let error = OpenAiCompatibleProvider::try_from_config(config, Some("sk-test".to_string()))
             .expect_err("invalid base url");
 
+        assert_eq!(error.code, ProviderErrorCode::InvalidBaseUrl);
+    }
+
+    #[test]
+    fn try_from_config_rejects_file_protocol_and_embedded_credentials() {
+        let mut file_config = provider_config("file:///tmp/provider".to_string());
+        file_config.custom_headers.clear();
+        let file_error = OpenAiCompatibleProvider::try_from_config(
+            file_config,
+            Some("sk-test".to_string()),
+        )
+        .expect_err("file protocol should be rejected");
+        assert_eq!(file_error.code, ProviderErrorCode::InvalidBaseUrl);
+
+        let mut credential_config =
+            provider_config("https://user:pass@example.com/v1".to_string());
+        credential_config.custom_headers.clear();
+        let credential_error = OpenAiCompatibleProvider::try_from_config(
+            credential_config,
+            Some("sk-test".to_string()),
+        )
+        .expect_err("embedded credentials should be rejected");
+        assert_eq!(credential_error.code, ProviderErrorCode::InvalidBaseUrl);
+    }
+
+    #[test]
+    fn try_from_config_rejects_query_and_fragment_in_base_url() {
+        let mut config =
+            provider_config("https://example.com/v1?debug=true#fragment".to_string());
+        config.custom_headers.clear();
+        let error = OpenAiCompatibleProvider::try_from_config(config, Some("sk-test".to_string()))
+            .expect_err("query string should be rejected");
         assert_eq!(error.code, ProviderErrorCode::InvalidBaseUrl);
     }
 

--- a/apps/desktop/src/stores/settings.ts
+++ b/apps/desktop/src/stores/settings.ts
@@ -26,6 +26,11 @@ import {
   type RoutingKind,
   type ThemeMode,
 } from "@cliplingo/shared-types";
+import {
+  validateHeaderNameInput,
+  validateHeaderValueInput,
+  validateProviderBaseUrl,
+} from "@/utils/security";
 
 export interface ProviderDraft extends Omit<ProviderConfig, "organization"> {
   apiKeyDraft: string;
@@ -151,51 +156,18 @@ function validateLanguageList(value: readonly string[], fieldName: string): Fiel
 }
 
 function validateUrl(value: string): FieldValidation {
-  const trimmed = value.trim();
-  if (!trimmed) {
-    return createEmptyField("Base URL is required.");
-  }
-
-  try {
-    const parsed = new URL(trimmed);
-    if (!["https:", "http:"].includes(parsed.protocol)) {
-      return createEmptyField("Use http or https for the Base URL.");
-    }
-
-    if (parsed.protocol === "http:" && !["localhost", "127.0.0.1", "::1"].includes(parsed.hostname)) {
-      return createEmptyField("HTTP is only allowed for localhost providers.");
-    }
-  } catch {
-    return createEmptyField("Base URL must be a valid URL.");
-  }
-
-  return createValidField();
+  const message = validateProviderBaseUrl(value);
+  return message ? createEmptyField(message) : createValidField();
 }
 
 function validateHeaderName(value: string): FieldValidation {
-  const trimmed = value.trim();
-  if (!trimmed) {
-    return createEmptyField("Header name is required.");
-  }
-
-  if (/[\r\n]/.test(trimmed)) {
-    return createEmptyField("Header name cannot contain line breaks.");
-  }
-
-  return createValidField();
+  const message = validateHeaderNameInput(value);
+  return message ? createEmptyField(message) : createValidField();
 }
 
 function validateHeaderValue(value: string): FieldValidation {
-  const trimmed = value.trim();
-  if (!trimmed) {
-    return createEmptyField("Header value is required.");
-  }
-
-  if (/[\r\n]/.test(trimmed)) {
-    return createEmptyField("Header value cannot contain line breaks.");
-  }
-
-  return createValidField();
+  const message = validateHeaderValueInput(value);
+  return message ? createEmptyField(message) : createValidField();
 }
 
 function validateShortcut(value: string): FieldValidation {

--- a/apps/desktop/src/stores/translation.ts
+++ b/apps/desktop/src/stores/translation.ts
@@ -2,6 +2,7 @@ import { computed, ref } from "vue";
 import { defineStore } from "pinia";
 import { invoke } from "@tauri-apps/api/core";
 import { getCurrentWindow } from "@tauri-apps/api/window";
+import { sanitizePlainText } from "@/utils/security";
 import type {
   TranslationCommandOutput,
   TranslationRequestInput,
@@ -18,19 +19,7 @@ interface TranslationErrorState {
 }
 
 function normalizeText(text: string): string {
-  return text
-    .replace(/\r\n?/g, "\n")
-    .split("")
-    .filter((character) => {
-      const code = character.charCodeAt(0);
-      return (
-        character === "\n" ||
-        character === "\t" ||
-        (code >= 0x20 && code !== 0x7f)
-      );
-    })
-    .join("")
-    .trim();
+  return sanitizePlainText(text);
 }
 
 function copyToClipboard(text: string): Promise<void> {

--- a/apps/desktop/src/utils/security.ts
+++ b/apps/desktop/src/utils/security.ts
@@ -1,0 +1,82 @@
+const HEADER_NAME_PATTERN = /^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$/;
+
+export function sanitizePlainText(value: string): string {
+  return value
+    .replace(/\r\n?/g, "\n")
+    .split("")
+    .filter((character) => {
+      const code = character.charCodeAt(0);
+      return (
+        character === "\n" ||
+        character === "\t" ||
+        (code >= 0x20 && code !== 0x7f)
+      );
+    })
+    .join("")
+    .trim();
+}
+
+export function validateProviderBaseUrl(value: string): string | null {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return "Base URL is required.";
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(trimmed);
+  } catch {
+    return "Base URL must be a valid URL.";
+  }
+
+  if (!["https:", "http:"].includes(parsed.protocol)) {
+    return "Use http or https for the Base URL.";
+  }
+
+  if (
+    parsed.protocol === "http:" &&
+    !["localhost", "127.0.0.1", "::1"].includes(parsed.hostname)
+  ) {
+    return "HTTP is only allowed for localhost providers.";
+  }
+
+  if (parsed.username || parsed.password) {
+    return "Base URL must not include embedded credentials.";
+  }
+
+  if (parsed.search || parsed.hash) {
+    return "Base URL must not include query strings or fragments.";
+  }
+
+  return null;
+}
+
+export function validateHeaderNameInput(value: string): string | null {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return "Header name is required.";
+  }
+
+  if (/[\r\n]/.test(trimmed)) {
+    return "Header name cannot contain line breaks.";
+  }
+
+  if (!HEADER_NAME_PATTERN.test(trimmed)) {
+    return "Header name contains unsupported characters.";
+  }
+
+  return null;
+}
+
+export function validateHeaderValueInput(value: string): string | null {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return "Header value is required.";
+  }
+
+  if (/[\r\n]/.test(trimmed)) {
+    return "Header value cannot contain line breaks.";
+  }
+
+  return null;
+}


### PR DESCRIPTION
## Summary
- add shared frontend security validators for provider URLs, headers, and plain-text sanitization
- reuse those validators in settings and translation popup state handling
- harden OpenAI-compatible base URL parsing against unsafe protocols, embedded credentials, queries, and fragments, with tests

## Validation
- pnpm --dir apps/desktop lint
- pnpm --dir apps/desktop typecheck
- pnpm --dir apps/desktop build
- source ~/.cargo/env && cargo test --manifest-path apps/desktop/src-tauri/Cargo.toml provider
- source ~/.cargo/env && cargo check --manifest-path apps/desktop/src-tauri/Cargo.toml